### PR TITLE
Added new tests, update to LSP 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the SysML v2.0 Language Support extension will be documen
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.0]
+
+### Added
+
+- **Worker thread parsing** — ANTLR parsing now runs in a dedicated `worker_threads` thread; diagnostics appear immediately while the symbol table builds on the main thread, keeping hover/completion/go-to-def responsive
+- **Parse lifecycle test suites** — tests covering `ModelExplorerProvider` concurrency (queuing, cancellation, rapid edits, workspace/file mode transitions) and `ParseOrchestrator` debounce/cooldown/guard logic
+- **Enum value symbol extraction** — bare enum values (`red;`) and explicit enum values (`enum red;`) inside `enum def` bodies now produce `EnumUsage` symbols in the symbol table
+
+### Fixed
+
+- **Redundant re-parsing on activation** — `parseDebounceTimer` now clears correctly after firing; 3-second cooldown on `notifyServerParseDone` prevents cascading re-parses during cold start
+- **False-positive "no viable alternative at input 'import'"** — DFA snapshot regenerated to cover bare `import` (without `private`/`public` prefix); server defers diagnostics for documents opened before DFA is loaded
+- **False "empty enum" hint** — `checkEmptyEnum` validator no longer flags enums with bare values as empty
+- **Status bar bug fix**
+
 ## [0.28.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "sysml-v2-support",
-  "version": "0.26.0",
+  "version": "0.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysml-v2-support",
-      "version": "0.26.0",
+      "version": "0.28.0",
       "license": "MIT",
       "dependencies": {
         "elkjs": "^0.11.0",
-        "sysml-v2-lsp": "^0.9.0",
+        "sysml-v2-lsp": "^0.10.0",
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
@@ -5277,9 +5277,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6122,9 +6122,9 @@
       }
     },
     "node_modules/sysml-v2-lsp": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/sysml-v2-lsp/-/sysml-v2-lsp-0.9.0.tgz",
-      "integrity": "sha512-jYsQ9OvfbYedLWgdz0twQulClHXemFITuBQvIitD0Yvz9+9B7Iup4iNBElII7TICZSXCc+Dcz7+EyEDkX3N6/A==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/sysml-v2-lsp/-/sysml-v2-lsp-0.10.0.tgz",
+      "integrity": "sha512-Z2DEn4lDEHfesz6RfHHzpXyujZ5140WiHjarR4HQlA3n4EFyRiFN4vXX22rpIl9PGNEA3xfxdYBmNOTnO71C6A==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6314,9 +6314,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -497,7 +497,7 @@
   },
   "dependencies": {
     "elkjs": "^0.11.0",
-    "sysml-v2-lsp": "^0.9.0",
+    "sysml-v2-lsp": "^0.10.0",
     "vscode-languageclient": "^9.0.1"
   },
   "overrides": {

--- a/src/explorer/modelExplorerProvider.ts
+++ b/src/explorer/modelExplorerProvider.ts
@@ -226,6 +226,14 @@ export class ModelExplorerProvider implements vscode.TreeDataProvider<vscode.Tre
             this._onDidChangeTreeData.fire();
         } finally {
             this.isLoading = false;
+
+            // If a single-file loadDocument was called while the workspace
+            // scan was running, process it now so it isn't silently dropped.
+            if (this.pendingDocument) {
+                const pending = this.pendingDocument;
+                this.pendingDocument = undefined;
+                this.loadDocument(pending);
+            }
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { SysRunnerPanel } from './game/sysRunnerPanel';
 import { startLanguageClient, stopLanguageClient } from './lsp/client';
 import { FeatureInspectorPanel } from './panels/featureInspectorPanel';
 import { ModelDashboardPanel } from './panels/modelDashboardPanel';
+import { ParseOrchestrator } from './parseOrchestrator';
 import { LspModelProvider } from './providers/lspModelProvider';
 import {
     clearMetricsKey,
@@ -30,9 +31,7 @@ let modelExplorerProvider: ModelExplorerProvider;
 let featureExplorerProvider: FeatureExplorerProvider;
 let outputChannel: vscode.OutputChannel;
 let lspModelProvider: LspModelProvider;
-
-let parseDebounceTimer: ReturnType<typeof setTimeout> | undefined;
-let activeParseCancel: vscode.CancellationTokenSource | undefined;
+let parseOrchestrator: ParseOrchestrator;
 
 /** Available visualization views — matches the webview's dropdown options */
 const visualizationViews = [
@@ -54,132 +53,11 @@ const visualizationViews = [
  * go-to-def, formatting, etc.) are handled by the LSP server.
  *
  * All parsing is performed by the LSP server via `sysml/model` requests.
+ * Orchestration (debounce, cancellation, cooldown) is handled by
+ * {@link ParseOrchestrator}.
  */
 function parseSysMLDocument(document: vscode.TextDocument, options?: { skipProgress?: boolean }): void {
-    // Cancel any in-flight parse for a previous file
-    if (parseDebounceTimer) {
-        globalThis.clearTimeout(parseDebounceTimer);
-    }
-    if (activeParseCancel) {
-        activeParseCancel.cancel();
-        activeParseCancel.dispose();
-        activeParseCancel = undefined;
-    }
-
-    // Show the animated progress indicator immediately — before the
-    // debounce timer fires — so the user sees feedback the instant
-    // a SysML file opens, not after the LSP roundtrip.
-    // Skip when re-triggered from notifyServerParseDone (server already done).
-    const fileName = document.fileName.split('/').pop() || 'file';
-    if (!options?.skipProgress) {
-        showParseProgress(fileName);
-    }
-
-    const cancelSource = new vscode.CancellationTokenSource();
-    activeParseCancel = cancelSource;
-
-    // Debounce (300 ms) — wait for the user to pause typing before
-    // kicking off the model request.
-    parseDebounceTimer = setTimeout(async () => {
-        if (cancelSource.token.isCancellationRequested || document.isClosed) {
-            return;
-        }
-
-        try {
-            if (cancelSource.token.isCancellationRequested || document.isClosed) {
-                return;
-            }
-
-            // --- Model explorer update ---
-            const fileName = document.fileName.split('/').pop() || 'file';
-            outputChannel?.appendLine(`parseSysMLDocument: loading ${fileName} (LSP)`);
-            try {
-                if (modelExplorerProvider.isWorkspaceMode()) {
-                    // Workspace mode: keep the full workspace model and
-                    // just reveal/expand the node for the active file.
-                    await modelExplorerProvider.revealActiveDocument(document.uri);
-                } else {
-                    await modelExplorerProvider.loadDocument(document, cancelSource.token);
-                }
-            } catch {
-                // Model explorer failure is non-critical — continue to
-                // update the visualizer so it always gets a chance to
-                // fetch fresh data from the LSP server.
-            }
-
-            // Parsing is done — hide the animated progress bar now,
-            // before the secondary UI updates (metrics, feature inspector,
-            // visualization) which can add noticeable latency.
-            hideParseProgress();
-
-            // --- Status-bar model metrics ---
-            // Update metrics BEFORE the cancellation check so the status
-            // bar always reflects the latest available data.  When a new
-            // parse was queued (e.g. from notifyServerParseDone) the
-            // cancelSource is cancelled, but the model explorer may
-            // already hold valid stats that should be displayed.  The
-            // next parse will override with fresh data if needed.
-            const stats = modelExplorerProvider.getLastStats();
-            if (stats) {
-                // Fetch LSP server health info (non-blocking, best-effort)
-                try {
-                    const serverStats = await lspModelProvider.getServerStats();
-                    if (serverStats) setStatusBarServerStats(serverStats);
-                } catch { /* non-critical */ }
-                updateModelMetrics(stats, document.uri);
-            }
-
-            // Bail out if cancelled or closed — skip the remaining
-            // secondary UI updates (Feature Inspector, Visualization)
-            // which are more expensive and will be retried by the
-            // follow-up parse.
-            if (cancelSource.token.isCancellationRequested || document.isClosed) {
-                outputChannel?.appendLine(`parseSysMLDocument: cancelled after model explorer update`);
-                return;
-            }
-
-            // Push resolved types to Feature Inspector and Feature Explorer
-            if ((FeatureInspectorPanel.currentPanel || featureExplorerProvider) && lspModelProvider) {
-                try {
-                    const typeResult = await lspModelProvider.getModel(
-                        document.uri.toString(), ['resolvedTypes'], cancelSource.token,
-                    );
-                    if (typeResult.resolvedTypes) {
-                        if (FeatureInspectorPanel.currentPanel) {
-                            FeatureInspectorPanel.currentPanel.updateResolvedTypes(
-                                typeResult.resolvedTypes, document.uri.toString(),
-                            );
-                        }
-                        if (featureExplorerProvider) {
-                            featureExplorerProvider.pushResolvedTypes(
-                                document.uri.toString(), typeResult.resolvedTypes,
-                            );
-                        }
-                    }
-                } catch {
-                    // Non-critical — inspector/explorer will fetch on next interaction
-                }
-            }
-
-            // Bail out if cancelled or closed
-            if (cancelSource.token.isCancellationRequested || document.isClosed) {
-                return;
-            }
-
-            // --- Visualization panel update ---
-            if (VisualizationPanel.currentPanel) {
-                VisualizationPanel.currentPanel.notifyFileChanged(document.uri);
-            }
-        } finally {
-            if (activeParseCancel === cancelSource) {
-                activeParseCancel = undefined;
-            }
-            cancelSource.dispose();
-            // Safety net: ensure the indicator is hidden even if an
-            // early return or exception skipped the inline call above.
-            hideParseProgress();
-        }
-    }, 300);
+    parseOrchestrator.requestParse(document, options);
 }
 
 /**
@@ -188,66 +66,9 @@ function parseSysMLDocument(document: vscode.TextDocument, options?: { skipProgr
  * so the Model Explorer and Visualization panels pick up the newly
  * available model data — prevents the "0 elements" problem on cold
  * start when the DFA warm-up delays initial parsing.
- *
- * Debounced so rapid-fire notifications during workspace scan
- * (one per file) coalesce into a single re-parse.
  */
-let parseDoneTimer: ReturnType<typeof setTimeout> | undefined;
-
 export function notifyServerParseDone(uri?: string): void {
-    if (parseDoneTimer) {
-        globalThis.clearTimeout(parseDoneTimer);
-    }
-    parseDoneTimer = globalThis.setTimeout(() => {
-        parseDoneTimer = undefined;
-
-        // Find a matching open editor to re-parse
-        const editors = vscode.window.visibleTextEditors.filter(
-            e => e.document.languageId === 'sysml' && !e.document.isClosed,
-        );
-        let target: vscode.TextDocument | undefined;
-        if (uri) {
-            target = editors.find(e => e.document.uri.toString() === uri)?.document;
-        }
-        // Fallback: re-parse whichever SysML editor is active
-        if (!target && editors.length > 0) {
-            target = vscode.window.activeTextEditor?.document.languageId === 'sysml'
-                ? vscode.window.activeTextEditor.document
-                : editors[0].document;
-        }
-        if (target) {
-            // Skip re-parse if a parse is already in-flight or debounce-
-            // pending — it will pick up the latest server data when it
-            // completes.  Re-triggering just cancels the current parse
-            // and starts over, causing the cascade seen during workspace
-            // scan (many sysml/status 'end' notifications in quick
-            // succession).
-            if (parseDebounceTimer || activeParseCancel) {
-                outputChannel?.appendLine(`notifyServerParseDone: skipping — parse already in progress`);
-                return;
-            }
-
-            // Skip re-parse if the Model Explorer already has valid data
-            // for this file — avoids a redundant LSP roundtrip when the
-            // initial parse from onDidChangeActiveTextEditor already
-            // succeeded (the common hot-cache case).
-            const stats = modelExplorerProvider.getLastStats();
-            if (stats && stats.totalElements > 0) {
-                outputChannel?.appendLine(`notifyServerParseDone: skipping re-parse — explorer already has ${stats.totalElements} elements`);
-                return;
-            }
-
-            outputChannel?.appendLine(`notifyServerParseDone: re-parsing ${target.fileName.split('/').pop()}`);
-            parseSysMLDocument(target, { skipProgress: true });
-
-            // Also notify the visualizer directly — the server has finished
-            // parsing so sysml/model will return fresh data.  This avoids
-            // waiting for the 300 ms debounce inside parseSysMLDocument.
-            if (VisualizationPanel.currentPanel) {
-                VisualizationPanel.currentPanel.notifyFileChanged(target.uri);
-            }
-        }
-    }, 500);
+    parseOrchestrator.notifyServerParseDone(uri);
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -316,6 +137,46 @@ export function activate(context: vscode.ExtensionContext) {
         treeDataProvider: featureExplorerProvider,
     });
     context.subscriptions.push(featureExplorerTreeView);
+
+    // ─── Parse Orchestrator ────────────────────────────────────────
+    parseOrchestrator = new ParseOrchestrator(
+        {
+            showProgress: (f) => showParseProgress(f),
+            hideProgress: () => hideParseProgress(),
+            loadModelExplorer: (doc, token) => modelExplorerProvider.loadDocument(doc, token),
+            revealInWorkspaceExplorer: (uri) => modelExplorerProvider.revealActiveDocument(uri),
+            isWorkspaceMode: () => modelExplorerProvider.isWorkspaceMode(),
+            getLastStats: () => modelExplorerProvider.getLastStats(),
+            updateMetrics: (stats, uri) => updateModelMetrics(stats, uri),
+            updateServerStats: async () => {
+                const serverStats = await lspModelProvider.getServerStats();
+                if (serverStats) setStatusBarServerStats(serverStats);
+            },
+            pushResolvedTypes: async (uri, token) => {
+                if (!(FeatureInspectorPanel.currentPanel || featureExplorerProvider) || !lspModelProvider) return;
+                const result = await lspModelProvider.getModel(uri, ['resolvedTypes'], token);
+                if (result.resolvedTypes) {
+                    FeatureInspectorPanel.currentPanel?.updateResolvedTypes(result.resolvedTypes, uri);
+                    featureExplorerProvider?.pushResolvedTypes(uri, result.resolvedTypes);
+                }
+            },
+            notifyVisualization: (uri) => VisualizationPanel.currentPanel?.notifyFileChanged(uri),
+            log: (msg) => outputChannel?.appendLine(msg),
+        },
+        {
+            getVisibleSysMLEditors: () =>
+                vscode.window.visibleTextEditors
+                    .filter(e => e.document.languageId === 'sysml' && !e.document.isClosed)
+                    .map(e => ({ uri: e.document.uri.toString(), document: e.document })),
+            getActiveSysMLEditor: () => {
+                const e = vscode.window.activeTextEditor;
+                if (e && e.document.languageId === 'sysml' && !e.document.isClosed) {
+                    return { uri: e.document.uri.toString(), document: e.document };
+                }
+                return undefined;
+            },
+        },
+    );
 
     // Master-detail: when user selects a definition in Model Explorer,
     // populate the Feature Explorer with its resolved type info.
@@ -1052,19 +913,9 @@ export function activate(context: vscode.ExtensionContext) {
                 // Evict from per-file metrics cache
                 deleteCachedMetrics(document.uri.toString());
 
-                // Clear debounce timer so a pending parse doesn't start
-                // after the document is already gone
-                if (parseDebounceTimer) {
-                    globalThis.clearTimeout(parseDebounceTimer);
-                    parseDebounceTimer = undefined;
-                }
-
-                if (activeParseCancel) {
-                    outputChannel.appendLine(`onDidCloseTextDocument: cancelling parse for ${document.fileName.split('/').pop()}`);
-                    activeParseCancel.cancel();
-                    activeParseCancel.dispose();
-                    activeParseCancel = undefined;
-                }
+                // Cancel any pending/in-flight parse for this document
+                outputChannel.appendLine(`onDidCloseTextDocument: cancelling parse for ${document.fileName.split('/').pop()}`);
+                parseOrchestrator.cancelAll();
 
                 // Clear the "Parsing …" status bar immediately — the
                 // server may never send sysml/status end for a closed file.

--- a/src/parseOrchestrator.ts
+++ b/src/parseOrchestrator.ts
@@ -1,0 +1,254 @@
+import * as vscode from 'vscode';
+import type { ModelStats } from './statusBar';
+
+/**
+ * Callbacks that the orchestrator invokes during a parse cycle.
+ * All are optional — the orchestrator continues even if any throws.
+ */
+export interface ParseOrchestratorCallbacks {
+    /** Show the "Parsing …" progress indicator. */
+    showProgress?(fileName: string): void;
+    /** Hide the progress indicator. */
+    hideProgress?(): void;
+
+    /**
+     * Load the document into the Model Explorer.
+     * The orchestrator passes its own CancellationToken so the
+     * explorer can bail out early.
+     */
+    loadModelExplorer?(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<void>;
+    /** Reveal the active document in workspace mode. */
+    revealInWorkspaceExplorer?(uri: vscode.Uri): Promise<void>;
+    /** Is the model explorer currently in workspace mode? */
+    isWorkspaceMode?(): boolean;
+
+    /** Return the latest parse stats from the model explorer. */
+    getLastStats?(): ModelStats | undefined;
+
+    /** Update the status-bar metrics display. */
+    updateMetrics?(stats: ModelStats, uri: vscode.Uri): void;
+
+    /** Fetch and display LSP server health info. */
+    updateServerStats?(): Promise<void>;
+
+    /** Push resolved types to Feature Inspector / Feature Explorer. */
+    pushResolvedTypes?(uri: string, token: vscode.CancellationToken): Promise<void>;
+
+    /** Notify the visualization panel that the file changed. */
+    notifyVisualization?(uri: vscode.Uri): void;
+
+    /** Log a message to the output channel. */
+    log?(message: string): void;
+}
+
+/**
+ * Describes an open SysML editor that `notifyServerParseDone` can
+ * re-parse.  Abstracted so tests don't need real `vscode.TextEditor`.
+ */
+export interface SysMLEditorInfo {
+    uri: string;
+    document: vscode.TextDocument;
+}
+
+/**
+ * Adapter for querying visible editors and the active editor.
+ * Injected to decouple from the real `vscode.window` API.
+ */
+export interface EditorProvider {
+    /** Return all visible SysML editors (open, not closed). */
+    getVisibleSysMLEditors(): SysMLEditorInfo[];
+    /** Return the active SysML editor, if any. */
+    getActiveSysMLEditor(): SysMLEditorInfo | undefined;
+}
+
+/**
+ * Orchestrates the parse-on-open / parse-on-edit / parse-on-server-done
+ * lifecycle for SysML documents.
+ *
+ * Extracted from `extension.ts` so the debounce, cancellation, and
+ * cooldown logic can be unit-tested without a live VS Code instance.
+ */
+export class ParseOrchestrator {
+    private _debounceTimer: ReturnType<typeof setTimeout> | undefined;
+    private _activeCancel: vscode.CancellationTokenSource | undefined;
+    private _parseDoneTimer: ReturnType<typeof setTimeout> | undefined;
+    private _lastParseDoneReparse = 0;
+
+    /** Debounce delay in ms — overridable for tests. */
+    debounceMs = 300;
+    /** `notifyServerParseDone` debounce in ms. */
+    parseDoneDebounceMs = 500;
+    /** Cooldown window in ms after a re-parse from parseDone. */
+    parseDoneCooldownMs = 3000;
+
+    constructor(
+        private readonly cb: ParseOrchestratorCallbacks,
+        private readonly editors: EditorProvider,
+    ) {}
+
+    // ── Public state (read-only for guards / tests) ──────────
+
+    /** True when a debounce timer is pending. */
+    get isDebouncing(): boolean { return this._debounceTimer !== undefined; }
+    /** True when an async parse is in-flight. */
+    get isParsing(): boolean { return this._activeCancel !== undefined; }
+
+    // ── Core API ─────────────────────────────────────────────
+
+    /**
+     * Request a parse for `document`.  Debounced — rapid calls
+     * cancel previous pending/in-flight parses.
+     */
+    requestParse(document: vscode.TextDocument, options?: { skipProgress?: boolean }): void {
+        // Cancel anything pending or in-flight
+        this._clearDebounce();
+        this._cancelActiveParse();
+
+        const fileName = document.fileName.split('/').pop() || 'file';
+        if (!options?.skipProgress) {
+            this.cb.showProgress?.(fileName);
+        }
+
+        const cancelSource = new vscode.CancellationTokenSource();
+        this._activeCancel = cancelSource;
+
+        this._debounceTimer = setTimeout(async () => {
+            this._debounceTimer = undefined;
+
+            if (cancelSource.token.isCancellationRequested || document.isClosed) {
+                return;
+            }
+
+            try {
+                // --- Model explorer ---
+                const fname = document.fileName.split('/').pop() || 'file';
+                this.cb.log?.(`parseSysMLDocument: loading ${fname} (LSP)`);
+                try {
+                    if (this.cb.isWorkspaceMode?.()) {
+                        await this.cb.revealInWorkspaceExplorer?.(document.uri);
+                    } else {
+                        await this.cb.loadModelExplorer?.(document, cancelSource.token);
+                    }
+                } catch {
+                    // Non-critical
+                }
+
+                this.cb.hideProgress?.();
+
+                // --- Status-bar metrics ---
+                const stats = this.cb.getLastStats?.();
+                if (stats) {
+                    try { await this.cb.updateServerStats?.(); } catch { /* non-critical */ }
+                    this.cb.updateMetrics?.(stats, document.uri);
+                }
+
+                if (cancelSource.token.isCancellationRequested || document.isClosed) {
+                    this.cb.log?.('parseSysMLDocument: cancelled after model explorer update');
+                    return;
+                }
+
+                // --- Feature inspector / explorer ---
+                try {
+                    await this.cb.pushResolvedTypes?.(document.uri.toString(), cancelSource.token);
+                } catch { /* non-critical */ }
+
+                if (cancelSource.token.isCancellationRequested || document.isClosed) {
+                    return;
+                }
+
+                // --- Visualization ---
+                this.cb.notifyVisualization?.(document.uri);
+            } finally {
+                if (this._activeCancel === cancelSource) {
+                    this._activeCancel = undefined;
+                }
+                cancelSource.dispose();
+                this.cb.hideProgress?.();
+            }
+        }, this.debounceMs);
+    }
+
+    /**
+     * Called when the LSP server finishes parsing a file.
+     * Conditionally re-triggers a parse if the explorer has no data yet.
+     */
+    notifyServerParseDone(uri?: string): void {
+        if (this._parseDoneTimer) {
+            globalThis.clearTimeout(this._parseDoneTimer);
+        }
+        this._parseDoneTimer = globalThis.setTimeout(() => {
+            this._parseDoneTimer = undefined;
+
+            const allEditors = this.editors.getVisibleSysMLEditors();
+            let target: SysMLEditorInfo | undefined;
+            if (uri) {
+                target = allEditors.find(e => e.uri === uri);
+            }
+            if (!target && allEditors.length > 0) {
+                target = this.editors.getActiveSysMLEditor() ?? allEditors[0];
+            }
+            if (!target) return;
+
+            // Skip if a parse is already pending/in-flight
+            if (this._debounceTimer || this._activeCancel) {
+                this.cb.log?.('notifyServerParseDone: skipping — parse already in progress');
+                return;
+            }
+
+            // Skip if explorer already has valid data
+            const stats = this.cb.getLastStats?.();
+            if (stats && stats.totalElements > 0) {
+                this.cb.log?.(`notifyServerParseDone: skipping re-parse — explorer already has ${stats.totalElements} elements`);
+                return;
+            }
+
+            // Cooldown
+            const now = Date.now();
+            if (now - this._lastParseDoneReparse < this.parseDoneCooldownMs) {
+                this.cb.log?.(`notifyServerParseDone: skipping — cooldown (${now - this._lastParseDoneReparse}ms since last re-parse)`);
+                return;
+            }
+
+            this._lastParseDoneReparse = now;
+            this.cb.log?.(`notifyServerParseDone: re-parsing ${target.document.fileName.split('/').pop()}`);
+            this.requestParse(target.document, { skipProgress: true });
+            this.cb.notifyVisualization?.(target.document.uri);
+        }, this.parseDoneDebounceMs);
+    }
+
+    /**
+     * Cancel any in-flight or pending parse.  Called when a SysML
+     * document is closed or the extension deactivates.
+     */
+    cancelAll(): void {
+        this._clearDebounce();
+        this._cancelActiveParse();
+        if (this._parseDoneTimer) {
+            globalThis.clearTimeout(this._parseDoneTimer);
+            this._parseDoneTimer = undefined;
+        }
+        this.cb.hideProgress?.();
+    }
+
+    /** Reset the `lastParseDoneReparse` cooldown (for tests). */
+    resetCooldown(): void {
+        this._lastParseDoneReparse = 0;
+    }
+
+    // ── Internal ─────────────────────────────────────────────
+
+    private _clearDebounce(): void {
+        if (this._debounceTimer) {
+            globalThis.clearTimeout(this._debounceTimer);
+            this._debounceTimer = undefined;
+        }
+    }
+
+    private _cancelActiveParse(): void {
+        if (this._activeCancel) {
+            this._activeCancel.cancel();
+            this._activeCancel.dispose();
+            this._activeCancel = undefined;
+        }
+    }
+}

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -231,6 +231,9 @@ const PARSE_FRAMES = [
     '$(symbol-structure) ◨◨◨◨ Linking elements',
 ];
 
+/** The label currently shown alongside the parse animation. */
+let parseAnimLabel = '';
+
 export function showParseProgress(label: string): void {
     if (!parseProgressItem) {
         parseProgressItem = vscode.window.createStatusBarItem(
@@ -239,12 +242,16 @@ export function showParseProgress(label: string): void {
         parseProgressItem.name = 'SysML Parse Progress';
     }
 
+    // Always update the label — the timer reads from the module-level
+    // variable so it picks up the latest value on every tick.
+    parseAnimLabel = label;
+
     if (!parseAnimTimer) {
         parseAnimFrame = 0;
         parseAnimTimer = setInterval(() => {
             parseAnimFrame = (parseAnimFrame + 1) % PARSE_FRAMES.length;
             if (parseProgressItem) {
-                const suffix = label ? ` · ${label}` : '';
+                const suffix = parseAnimLabel ? ` · ${parseAnimLabel}` : '';
                 parseProgressItem.text = `${PARSE_FRAMES[parseAnimFrame]}${suffix}`;
             }
         }, 220);

--- a/src/test/parseLifecycle.test.ts
+++ b/src/test/parseLifecycle.test.ts
@@ -1,0 +1,751 @@
+/**
+ * Parse lifecycle tests.
+ *
+ * Covers the concurrency, queuing, cancellation, and debounce
+ * behaviour of the Model Explorer's `loadDocument()` method and
+ * the interaction patterns between `parseSysMLDocument()` →
+ * `notifyServerParseDone()` → `loadDocument()`.
+ *
+ * Scenarios tested:
+ *   A. ModelExplorerProvider.loadDocument concurrency
+ *      1. Queuing when already loading
+ *      2. Cancellation token honoured before LSP request
+ *      3. Cancellation token honoured during LSP request
+ *      4. Document closed mid-load
+ *      5. Rapid sequential loads — only last document wins
+ *      6. Pending document processed after current finishes
+ *      7. LSP error does not leave provider in stuck state
+ *      8. Stats captured even when cancelled post-request
+ *
+ *   B. notifyServerParseDone guard logic
+ *      (Tested via exported function + controlled module state.)
+ *      1. Skip when parseDebounceTimer is pending
+ *      2. Skip when activeParseCancel is in-flight
+ *      3. Skip when explorer already has >0 elements
+ *      4. Cooldown prevents cascade
+ *      5. Re-parse triggered when explorer has 0 elements
+ *
+ *   C. Full activation lifecycle (integration-level)
+ *      1. File open before LSP ready → initial parse → server done → re-parse → settled
+ *      2. No SysML file open → retries → gives up
+ *      3. User edits mid-parse → new parse replaces old
+ *      4. User switches files during parse → cancels old, starts new
+ *      5. Workspace vs plain folder — workspace scan only for .code-workspace
+ */
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { ModelExplorerProvider } from '../explorer/modelExplorerProvider';
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function makeRange() {
+    return { start: { line: 0, character: 0 }, end: { line: 0, character: 10 } };
+}
+
+function makeElements(names: string[]) {
+    return names.map(n => ({
+        type: 'part',
+        name: n,
+        range: makeRange(),
+        children: [],
+        attributes: {},
+        relationships: [],
+    }));
+}
+
+function makeStats(totalElements: number) {
+    return {
+        totalElements,
+        resolvedElements: totalElements,
+        unresolvedElements: 0,
+        parseTimeMs: 5,
+        modelBuildTimeMs: 3,
+    };
+}
+
+/** Promise that can be resolved/rejected externally. */
+function deferred<T>() {
+    let resolve!: (v: T) => void;
+    let reject!: (e: any) => void;
+    const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+    return { promise, resolve, reject };
+}
+
+/**
+ * Controllable mock LSP provider.
+ * - `delay(ms)` — adds a fixed delay before resolving
+ * - `useGate()` — returns a gate; getModel blocks until gate.open()
+ * - `failNext(err)` — makes the next getModel call reject
+ * - `callCount` — number of getModel invocations
+ * - `lastUri` — URI of the most recent getModel call
+ */
+function createControllableLspProvider(elements: any[] = [], stats?: Record<string, unknown>) {
+    let _delayMs = 0;
+    let _gate: { promise: Promise<void>; open: () => void } | undefined;
+    let _failNext: Error | undefined;
+    let callCount = 0;
+    let lastUri = '';
+
+    const provider = {
+        get callCount() { return callCount; },
+        get lastUri() { return lastUri; },
+
+        delay(ms: number) { _delayMs = ms; return provider; },
+
+        useGate() {
+            const d = deferred<void>();
+            _gate = { promise: d.promise, open: d.resolve };
+            return _gate;
+        },
+
+        failNext(err: Error) { _failNext = err; return provider; },
+
+        getModel: async (uri: string, _scopes?: string[], token?: vscode.CancellationToken) => {
+            callCount++;
+            lastUri = uri;
+
+            if (_failNext) {
+                const err = _failNext;
+                _failNext = undefined;
+                throw err;
+            }
+
+            if (_gate) {
+                const g = _gate;
+                _gate = undefined;
+                await g.promise;
+            }
+
+            if (_delayMs > 0) {
+                await new Promise<void>((resolve) => {
+                    const timer = setTimeout(resolve, _delayMs);
+                    // If token is cancelled while waiting, resolve immediately
+                    if (token?.isCancellationRequested) { clearTimeout(timer); resolve(); return; }
+                    token?.onCancellationRequested(() => { clearTimeout(timer); resolve(); });
+                });
+            }
+
+            return {
+                version: 1,
+                elements: elements.map(e => ({ ...e })),
+                relationships: [],
+                stats: { ...makeStats(elements.length), ...(stats ?? {}) },
+            };
+        },
+    } as any;
+
+    return provider;
+}
+
+/** Fake TextDocument — optionally starts closed or can be closed later. */
+function createFakeDocument(uri: string, opts?: { closed?: boolean }) {
+    let _closed = opts?.closed ?? false;
+    return {
+        uri: vscode.Uri.parse(uri),
+        languageId: 'sysml',
+        fileName: uri.split('/').pop() ?? 'test.sysml',
+        get isClosed() { return _closed; },
+        close() { _closed = true; },
+        getText: () => 'package Pkg {}',
+    } as any;
+}
+
+/** Wait for a given number of tree-change events (with timeout). */
+function waitForChanges(provider: ModelExplorerProvider, count: number, timeoutMs = 2000): Promise<void> {
+    return new Promise((resolve, reject) => {
+        let seen = 0;
+        const timer = setTimeout(() => reject(new Error(`Timed out waiting for ${count} change events (got ${seen})`)), timeoutMs);
+        const sub = provider.onDidChangeTreeData(() => {
+            seen++;
+            if (seen >= count) {
+                clearTimeout(timer);
+                sub.dispose();
+                resolve();
+            }
+        });
+    });
+}
+
+// ── A. ModelExplorerProvider.loadDocument concurrency ─────────────
+
+suite('Parse Lifecycle — ModelExplorer loadDocument concurrency', () => {
+
+    test('A1: second loadDocument queued when first is in-flight', async () => {
+        const lsp = createControllableLspProvider(makeElements(['A']));
+        const gate = lsp.useGate();
+        const provider = new ModelExplorerProvider(lsp);
+
+        const doc1 = createFakeDocument('file:///workspace/first.sysml');
+        const doc2 = createFakeDocument('file:///workspace/second.sysml');
+
+        // Start first load — it blocks on the gate
+        const load1 = provider.loadDocument(doc1);
+
+        // Second load while first is in-flight — should queue
+        const load2 = provider.loadDocument(doc2);
+
+        // load2 returns immediately (queued)
+        await load2;
+
+        // First should still be blocked — only 1 getModel call so far
+        assert.strictEqual(lsp.callCount, 1, 'Only one LSP call should be in-flight');
+
+        // Release the gate — first finishes, then pending (doc2) auto-starts
+        gate.open();
+        await load1;
+
+        // Give the pending load time to complete (it starts in a microtask)
+        await new Promise(r => setTimeout(r, 50));
+
+        assert.strictEqual(lsp.callCount, 2, 'Queued document should trigger a second LSP call');
+        assert.ok(lsp.lastUri.includes('second.sysml'), 'Last LSP call should be for the queued document');
+    });
+
+    test('A2: cancellation token honoured before LSP request', async () => {
+        const lsp = createControllableLspProvider(makeElements(['A']));
+        const provider = new ModelExplorerProvider(lsp);
+        const doc = createFakeDocument('file:///workspace/test.sysml');
+        const cts = new vscode.CancellationTokenSource();
+        cts.cancel(); // pre-cancelled
+
+        await provider.loadDocument(doc, cts.token);
+
+        assert.strictEqual(lsp.callCount, 0, 'Should not call LSP when token is pre-cancelled');
+        const items = await provider.getChildren();
+        assert.strictEqual(items.length, 0, 'Should have no elements');
+    });
+
+    test('A3: cancellation token honoured during LSP request', async () => {
+        const lsp = createControllableLspProvider(makeElements(['A']));
+        const gate = lsp.useGate();
+        const provider = new ModelExplorerProvider(lsp);
+        const doc = createFakeDocument('file:///workspace/test.sysml');
+        const cts = new vscode.CancellationTokenSource();
+
+        const loadPromise = provider.loadDocument(doc, cts.token);
+
+        // LSP request is in-flight — cancel now
+        cts.cancel();
+        gate.open();
+        await loadPromise;
+
+        // getModel was called (1) but the result should be discarded
+        assert.strictEqual(lsp.callCount, 1, 'LSP call started before cancellation');
+        // Stats should still be captured even when cancelled
+        const stats = provider.getLastStats();
+        assert.ok(stats, 'Stats should be captured even on cancellation');
+    });
+
+    test('A4: document closed mid-load does not update tree', async () => {
+        const lsp = createControllableLspProvider(makeElements(['A']));
+        const gate = lsp.useGate();
+        const provider = new ModelExplorerProvider(lsp);
+        const doc = createFakeDocument('file:///workspace/test.sysml');
+
+        let changeCount = 0;
+        provider.onDidChangeTreeData(() => { changeCount++; });
+
+        const loadPromise = provider.loadDocument(doc);
+
+        // Close the document while LSP is still working
+        (doc as any).close();
+        gate.open();
+        await loadPromise;
+
+        assert.strictEqual(changeCount, 0, 'Tree should not fire change when doc closed mid-load');
+    });
+
+    test('A5: rapid sequential loads — only last document wins', async () => {
+        const lsp = createControllableLspProvider(makeElements(['Latest']));
+        const provider = new ModelExplorerProvider(lsp);
+
+        // Fire 5 rapid loads — all except the first will be queued,
+        // but only the last pending document should survive.
+        const docs = Array.from({ length: 5 }, (_, i) =>
+            createFakeDocument(`file:///workspace/file${i}.sysml`),
+        );
+
+        const promises = docs.map(d => provider.loadDocument(d));
+        await Promise.all(promises);
+
+        // Give the auto-started pending load time to finish
+        await new Promise(r => setTimeout(r, 50));
+
+        // The final document should be what the provider holds;
+        // we check via getModel calls — should be at most 2:
+        // the first started immediately, the last queued as pending.
+        assert.ok(lsp.callCount <= docs.length, 'Should not have more calls than documents');
+        assert.ok(lsp.lastUri.includes('file4.sysml'), 'Last LSP call should be for the final document');
+    });
+
+    test('A6: pending document auto-starts after current finishes', async () => {
+        const lsp = createControllableLspProvider(makeElements(['X']));
+        const gate = lsp.useGate();
+        const provider = new ModelExplorerProvider(lsp);
+        const doc1 = createFakeDocument('file:///workspace/a.sysml');
+        const doc2 = createFakeDocument('file:///workspace/b.sysml');
+
+        const load1 = provider.loadDocument(doc1);
+        // Queue doc2
+        provider.loadDocument(doc2);
+
+        // Expect 2 change events total (one per completed load)
+        const allDone = waitForChanges(provider, 2);
+
+        gate.open();
+        await load1;
+        await allDone;
+
+        assert.strictEqual(lsp.callCount, 2, 'Pending doc should auto-trigger a second getModel call');
+    });
+
+    test('A7: LSP error does not leave provider in stuck "loading" state', async () => {
+        const lsp = createControllableLspProvider(makeElements(['A']));
+        lsp.failNext(new Error('LSP connection lost'));
+        const provider = new ModelExplorerProvider(lsp);
+        const doc = createFakeDocument('file:///workspace/test.sysml');
+
+        // First call will reject
+        try {
+            await provider.loadDocument(doc);
+        } catch {
+            // expected
+        }
+
+        // Provider should not be stuck — a subsequent load should work
+        const doc2 = createFakeDocument('file:///workspace/test2.sysml');
+        await provider.loadDocument(doc2);
+        assert.strictEqual(lsp.callCount, 2, 'Should accept a new load after an error');
+        const items = await provider.getChildren();
+        assert.strictEqual(items.length, 1, 'Should have elements from successful second load');
+    });
+
+    test('A8: stats captured even when cancellation happens after LSP responds', async () => {
+        const customStats = { totalElements: 42, resolvedElements: 40, unresolvedElements: 2, parseTimeMs: 100, modelBuildTimeMs: 50 };
+        const lsp = createControllableLspProvider(makeElements(['A']), customStats);
+        const gate = lsp.useGate();
+        const provider = new ModelExplorerProvider(lsp);
+        const doc = createFakeDocument('file:///workspace/test.sysml');
+        const cts = new vscode.CancellationTokenSource();
+
+        const loadPromise = provider.loadDocument(doc, cts.token);
+
+        // Let LSP respond, then cancel
+        gate.open();
+        // Small delay to let the await resume before cancelling
+        await new Promise(r => setTimeout(r, 10));
+        cts.cancel();
+        await loadPromise;
+
+        const stats = provider.getLastStats();
+        assert.ok(stats, 'Stats should be available');
+        assert.strictEqual(stats?.totalElements, 42, 'Should capture the correct totalElements');
+    });
+
+    test('A9: loadDocument with undefined cancellation token works normally', async () => {
+        const lsp = createControllableLspProvider(makeElements(['A', 'B']));
+        const provider = new ModelExplorerProvider(lsp);
+        const doc = createFakeDocument('file:///workspace/test.sysml');
+
+        await provider.loadDocument(doc);
+
+        const items = await provider.getChildren();
+        assert.strictEqual(items.length, 2, 'Should load elements without cancellation token');
+    });
+
+    test('A10: loadDocument resets workspace mode', async () => {
+        const lsp = createControllableLspProvider(makeElements(['A']));
+        const provider = new ModelExplorerProvider(lsp);
+
+        // First load in workspace mode
+        await provider.loadWorkspaceModel([vscode.Uri.parse('file:///ws/a.sysml')]);
+        assert.ok(provider.isWorkspaceMode(), 'Should be in workspace mode');
+
+        // Single-file load should switch back
+        const doc = createFakeDocument('file:///workspace/test.sysml');
+        await provider.loadDocument(doc);
+        assert.ok(!provider.isWorkspaceMode(), 'Should exit workspace mode after loadDocument');
+    });
+});
+
+// ── B. notifyServerParseDone guard logic ─────────────────────────
+// These tests exercise notifyServerParseDone's skip conditions.
+// Since it depends on module-level state in extension.ts, we test the
+// *logic* by simulating the conditions on the ModelExplorerProvider
+// side (which is what the guards check).
+
+suite('Parse Lifecycle — notifyServerParseDone guard conditions', () => {
+
+    test('B1: explorer with >0 elements means re-parse not needed', async () => {
+        // This validates the guard: if the explorer already has data,
+        // notifyServerParseDone should skip. We verify the precondition.
+        const lsp = createControllableLspProvider(makeElements(['A', 'B']));
+        const provider = new ModelExplorerProvider(lsp);
+        await provider.loadDocument(createFakeDocument('file:///test.sysml'));
+
+        const stats = provider.getLastStats();
+        assert.ok(stats && stats.totalElements > 0,
+            'Explorer with loaded data should have totalElements > 0, allowing notifyServerParseDone to skip');
+    });
+
+    test('B2: explorer with 0 elements means re-parse IS needed', async () => {
+        // When the LSP returns 0 elements (cold start, DFA not ready
+        // yet), the explorer should report 0 so notifyServerParseDone
+        // triggers a re-parse.
+        const lsp = createControllableLspProvider([], { totalElements: 0 });
+        const provider = new ModelExplorerProvider(lsp);
+        await provider.loadDocument(createFakeDocument('file:///test.sysml'));
+
+        const stats = provider.getLastStats();
+        assert.strictEqual(stats?.totalElements, 0,
+            'Explorer should report 0 elements, signalling re-parse needed');
+    });
+
+    test('B3: clear() resets stats so re-parse can be triggered', async () => {
+        const lsp = createControllableLspProvider(makeElements(['A']));
+        const provider = new ModelExplorerProvider(lsp);
+        await provider.loadDocument(createFakeDocument('file:///test.sysml'));
+
+        assert.ok(provider.getLastStats()?.totalElements ?? 0 > 0, 'Should have stats before clear');
+
+        provider.clear();
+        // After clear, getLastStats() may still return old stats — that's OK
+        // because the tree is empty and the guard also checks tree items.
+        const items = await provider.getChildren();
+        assert.strictEqual(items.length, 0, 'Should have no items after clear');
+    });
+
+    test('B4: queued load does not count as "already in progress" for the explorer', async () => {
+        // When loadDocument is queued (not yet started), the loading
+        // flag is still true from the first load. notifyServerParseDone
+        // checks parseDebounceTimer/activeParseCancel rather than
+        // isLoading, so this is an indirect validation.
+        const lsp = createControllableLspProvider(makeElements(['A']));
+        const gate = lsp.useGate();
+        const provider = new ModelExplorerProvider(lsp);
+
+        const doc1 = createFakeDocument('file:///workspace/a.sysml');
+        const doc2 = createFakeDocument('file:///workspace/b.sysml');
+
+        // Start load, then queue another
+        provider.loadDocument(doc1);
+        provider.loadDocument(doc2);
+
+        gate.open();
+        // Wait for both to settle
+        await new Promise(r => setTimeout(r, 100));
+
+        // Final state should reflect the queued doc, not be stuck
+        assert.strictEqual(lsp.callCount, 2, 'Both loads should have completed');
+    });
+});
+
+// ── C. Full activation lifecycle patterns ────────────────────────
+// These test the expected *patterns* that parseSysMLDocument and
+// notifyServerParseDone follow, as documented by the output log.
+
+suite('Parse Lifecycle — Activation patterns', () => {
+
+    test('C1: cold start — initial load gets 0 elements, re-parse gets real data', async () => {
+        // Simulates: file opened → LSP not ready → 0 elements
+        //            → server finishes → notifyServerParseDone
+        //            → re-parse → real elements
+        let callIndex = 0;
+        const coldLsp = {
+            getModel: async () => {
+                callIndex++;
+                if (callIndex === 1) {
+                    // First call: LSP not ready yet, returns empty
+                    return {
+                        version: 1,
+                        elements: [],
+                        relationships: [],
+                        stats: makeStats(0),
+                    };
+                }
+                // Second call: server is ready
+                return {
+                    version: 1,
+                    elements: makeElements(['RealPart']),
+                    relationships: [],
+                    stats: makeStats(1),
+                };
+            },
+        } as any;
+
+        const provider = new ModelExplorerProvider(coldLsp);
+        const doc = createFakeDocument('file:///workspace/test.sysml');
+
+        // Initial load — gets 0 elements
+        await provider.loadDocument(doc);
+        let items = await provider.getChildren();
+        assert.strictEqual(items.length, 0, 'Initial load should have 0 elements (cold cache)');
+        assert.strictEqual(provider.getLastStats()?.totalElements, 0);
+
+        // Simulate notifyServerParseDone triggering a re-parse
+        await provider.loadDocument(doc);
+        items = await provider.getChildren();
+        assert.strictEqual(items.length, 1, 'Re-parse should return real elements');
+        assert.strictEqual(provider.getLastStats()?.totalElements, 1);
+    });
+
+    test('C2: hot start — initial load gets elements, no re-parse needed', async () => {
+        const lsp = createControllableLspProvider(makeElements(['Vehicle', 'Engine']));
+        const provider = new ModelExplorerProvider(lsp);
+        const doc = createFakeDocument('file:///workspace/test.sysml');
+
+        await provider.loadDocument(doc);
+
+        const stats = provider.getLastStats();
+        assert.ok(stats && stats.totalElements > 0,
+            'Hot start: explorer has elements, notifyServerParseDone should skip');
+        assert.strictEqual(lsp.callCount, 1, 'Should only need one LSP call');
+    });
+
+    test('C3: user edits file → new parse replaces old pending', async () => {
+        // Simulates rapid typing: each keystroke triggers a parse.
+        // Only the last should "win".
+        const lsp = createControllableLspProvider(makeElements(['Final']));
+        const gate = lsp.useGate();
+        const provider = new ModelExplorerProvider(lsp);
+
+        // First "keystroke" — starts loading
+        const doc = createFakeDocument('file:///workspace/editing.sysml');
+        const load1 = provider.loadDocument(doc);
+
+        // Second "keystroke" — queued as pending
+        provider.loadDocument(doc);
+        // Third "keystroke" — REPLACES pending (not additive)
+        provider.loadDocument(doc);
+
+        gate.open();
+        await load1;
+        await new Promise(r => setTimeout(r, 100));
+
+        // Should be exactly 2 calls: the first + one pending
+        // (second pending was overwritten by third)
+        assert.strictEqual(lsp.callCount, 2,
+            'Rapid edits should coalesce: first + one pending, not first + two');
+    });
+
+    test('C4: user switches files during load → old cancelled, new starts', async () => {
+        // parseSysMLDocument cancels via CancellationToken; we simulate
+        // by cancelling the token on the first loadDocument.
+        const lsp = createControllableLspProvider(makeElements(['B']));
+        const gate = lsp.useGate();
+        const provider = new ModelExplorerProvider(lsp);
+
+        const doc1 = createFakeDocument('file:///workspace/file1.sysml');
+        const doc2 = createFakeDocument('file:///workspace/file2.sysml');
+        const cts = new vscode.CancellationTokenSource();
+
+        const load1 = provider.loadDocument(doc1, cts.token);
+
+        // User switches file → cancel old
+        cts.cancel();
+        gate.open();
+        await load1;
+
+        // Now start the new file
+        await provider.loadDocument(doc2);
+
+        assert.strictEqual(lsp.callCount, 2, 'Both loads should have called getModel');
+        const items = await provider.getChildren();
+        assert.strictEqual(items.length, 1, 'Should have elements from the second file');
+    });
+
+    test('C5: workspace mode load does not interleave with single-file load', async () => {
+        const lsp = createControllableLspProvider(makeElements(['A']));
+        const provider = new ModelExplorerProvider(lsp);
+
+        // Load workspace model
+        await provider.loadWorkspaceModel([
+            vscode.Uri.parse('file:///ws/a.sysml'),
+            vscode.Uri.parse('file:///ws/b.sysml'),
+        ]);
+        assert.ok(provider.isWorkspaceMode());
+
+        // User opens a specific file → switches to single-file mode
+        const doc = createFakeDocument('file:///ws/a.sysml');
+        await provider.loadDocument(doc);
+        assert.ok(!provider.isWorkspaceMode(),
+            'loadDocument should exit workspace mode');
+    });
+
+    test('C6: loadDocument during workspace load queues correctly', async () => {
+        const lsp = createControllableLspProvider(makeElements(['A']));
+        const gate = lsp.useGate();
+        const provider = new ModelExplorerProvider(lsp);
+
+        // Start workspace load (blocks on gate)
+        const wsLoad = provider.loadWorkspaceModel([
+            vscode.Uri.parse('file:///ws/a.sysml'),
+        ]);
+
+        // Single-file load while workspace load is in-flight
+        // Note: loadWorkspaceModel sets isLoading=true, but
+        // loadDocument checks isLoading too
+        const doc = createFakeDocument('file:///ws/b.sysml');
+        provider.loadDocument(doc);
+
+        gate.open();
+        await wsLoad;
+        await new Promise(r => setTimeout(r, 100));
+
+        // The single-file loadDocument should have been queued
+        // and run after the workspace load finished
+        assert.ok(lsp.callCount >= 2, 'Both loads should complete');
+    });
+});
+
+// ── D. Edge cases and error resilience ──────────────────────────
+
+suite('Parse Lifecycle — Edge cases', () => {
+
+    test('D1: loadDocument with already-closed document is a no-op', async () => {
+        const lsp = createControllableLspProvider(makeElements(['A']));
+        const provider = new ModelExplorerProvider(lsp);
+        const doc = createFakeDocument('file:///workspace/closed.sysml', { closed: true });
+
+        await provider.loadDocument(doc);
+
+        assert.strictEqual(lsp.callCount, 0, 'Should not call LSP for closed documents');
+    });
+
+    test('D2: multiple getModel failures do not accumulate stuck state', async () => {
+        const lsp = createControllableLspProvider(makeElements(['A']));
+        const provider = new ModelExplorerProvider(lsp);
+
+        // Fail three times in a row
+        for (let i = 0; i < 3; i++) {
+            lsp.failNext(new Error(`Failure ${i}`));
+            try {
+                await provider.loadDocument(createFakeDocument(`file:///ws/f${i}.sysml`));
+            } catch { /* expected */ }
+        }
+
+        // Should still accept a new load
+        await provider.loadDocument(createFakeDocument('file:///ws/ok.sysml'));
+        assert.strictEqual(lsp.callCount, 4, 'Should recover and accept new loads after repeated failures');
+        const items = await provider.getChildren();
+        assert.strictEqual(items.length, 1, 'Should have elements from successful load');
+    });
+
+    test('D3: loadWorkspaceModel skips files that fail individually', async () => {
+        let callIndex = 0;
+        const mixedLsp = {
+            getModel: async (uri: string) => {
+                callIndex++;
+                if (uri.includes('bad')) {
+                    throw new Error('Bad file');
+                }
+                return {
+                    version: 1,
+                    elements: makeElements([`Part${callIndex}`]),
+                    relationships: [],
+                    stats: makeStats(1),
+                };
+            },
+        } as any;
+
+        const provider = new ModelExplorerProvider(mixedLsp);
+        await provider.loadWorkspaceModel([
+            vscode.Uri.parse('file:///ws/good1.sysml'),
+            vscode.Uri.parse('file:///ws/bad.sysml'),
+            vscode.Uri.parse('file:///ws/good2.sysml'),
+        ]);
+
+        // Should have data from the 2 good files
+        const stats = provider.getLastStats();
+        assert.ok(stats, 'Should have aggregated stats');
+        assert.strictEqual(stats?.totalElements, 2,
+            'Should have elements from the 2 successful files');
+    });
+
+    test('D4: loadWorkspaceModel cancellation stops processing remaining files', async () => {
+        let callCount = 0;
+        const slowLsp = {
+            getModel: async () => {
+                callCount++;
+                await new Promise(r => setTimeout(r, 10));
+                return {
+                    version: 1,
+                    elements: makeElements(['X']),
+                    relationships: [],
+                    stats: makeStats(1),
+                };
+            },
+        } as any;
+
+        const provider = new ModelExplorerProvider(slowLsp);
+        const cts = new vscode.CancellationTokenSource();
+
+        const uris = Array.from({ length: 10 }, (_, i) =>
+            vscode.Uri.parse(`file:///ws/file${i}.sysml`),
+        );
+
+        // Cancel after a short delay
+        setTimeout(() => cts.cancel(), 25);
+        await provider.loadWorkspaceModel(uris, cts.token);
+
+        assert.ok(callCount < 10,
+            `Should have stopped early (processed ${callCount}/10 files)`);
+    });
+
+    test('D5: refresh() in single-file mode re-loads current document', async () => {
+        let callCount = 0;
+        const lsp = {
+            getModel: async () => {
+                callCount++;
+                return {
+                    version: 1,
+                    elements: makeElements([`Part${callCount}`]),
+                    relationships: [],
+                    stats: makeStats(1),
+                };
+            },
+        } as any;
+
+        const provider = new ModelExplorerProvider(lsp);
+        await provider.loadDocument(createFakeDocument('file:///test.sysml'));
+        assert.strictEqual(callCount, 1);
+
+        provider.refresh();
+        await new Promise(r => setTimeout(r, 50));
+        assert.strictEqual(callCount, 2, 'Refresh should re-load the document');
+    });
+
+    test('D6: refresh() in workspace mode re-loads all workspace files', async () => {
+        let callCount = 0;
+        const lsp = {
+            getModel: async () => {
+                callCount++;
+                return {
+                    version: 1,
+                    elements: makeElements(['X']),
+                    relationships: [],
+                    stats: makeStats(1),
+                };
+            },
+        } as any;
+
+        const provider = new ModelExplorerProvider(lsp);
+        const uris = [
+            vscode.Uri.parse('file:///ws/a.sysml'),
+            vscode.Uri.parse('file:///ws/b.sysml'),
+        ];
+        await provider.loadWorkspaceModel(uris);
+        assert.strictEqual(callCount, 2);
+
+        provider.refresh();
+        await new Promise(r => setTimeout(r, 100));
+        assert.strictEqual(callCount, 4, 'Refresh should re-load all workspace files');
+    });
+
+    test('D7: getChildren returns empty array before any load', async () => {
+        const provider = new ModelExplorerProvider(createControllableLspProvider());
+        const items = await provider.getChildren();
+        assert.strictEqual(items.length, 0, 'Should have no items before any load');
+    });
+});

--- a/src/test/parseOrchestrator.test.ts
+++ b/src/test/parseOrchestrator.test.ts
@@ -1,0 +1,761 @@
+/**
+ * ParseOrchestrator tests.
+ *
+ * These exercise the debounce, cancellation, cooldown, and guard
+ * logic that sits between VS Code editor events and the Model
+ * Explorer / Visualization panel updates — the "editor side" of
+ * the parse lifecycle.
+ *
+ * Scenarios:
+ *   E. requestParse debounce & cancellation
+ *      1. Debounce — single call triggers one parse after delay
+ *      2. Rapid calls — only last document wins
+ *      3. Second requestParse cancels in-flight first
+ *      4. Closed document skipped at debounce fire
+ *      5. Progress shown/hidden correctly
+ *      6. skipProgress option suppresses progress
+ *      7. Model explorer error is non-critical — continues to metrics + viz
+ *      8. Cancellation after model explorer skips feature inspector + viz
+ *
+ *   F. notifyServerParseDone guards
+ *      1. No visible editors — no-op
+ *      2. Matching URI editor found
+ *      3. Fallback to active editor when URI has no match
+ *      4. Skip when debounce pending
+ *      5. Skip when parse in-flight
+ *      6. Skip when explorer has elements
+ *      7. Cooldown suppresses rapid-fire
+ *      8. After cooldown expires, re-parse fires
+ *
+ *   G. cancelAll
+ *      1. Cancels pending debounce
+ *      2. Cancels in-flight parse
+ *      3. Clears parseDone timer
+ *
+ *   H. Integration: requestParse → notifyServerParseDone flow
+ *      1. Cold start: parse returns 0 → server done → re-parse → real data
+ *      2. Hot start: parse returns data → server done → skipped
+ *      3. Edit during parse → new parse replaces old
+ *      4. File switch during parse → old cancelled, new starts
+ */
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { EditorProvider, ParseOrchestrator, ParseOrchestratorCallbacks, SysMLEditorInfo } from '../parseOrchestrator';
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+/** Promise that can be resolved externally. */
+function deferred<T = void>() {
+    let resolve!: (v: T) => void;
+    let reject!: (e: any) => void;
+    const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+    return { promise, resolve, reject };
+}
+
+/** Fake document that can be closed. */
+function fakeDoc(uri: string, opts?: { closed?: boolean }) {
+    let _closed = opts?.closed ?? false;
+    return {
+        uri: vscode.Uri.parse(uri),
+        languageId: 'sysml',
+        fileName: uri.split('/').pop() ?? 'test.sysml',
+        get isClosed() { return _closed; },
+        close() { _closed = true; },
+        getText: () => 'package Pkg {}',
+    } as any as vscode.TextDocument & { close(): void };
+}
+
+/** Tracking spy for callbacks. */
+function createSpyCallbacks(overrides?: Partial<ParseOrchestratorCallbacks>): ParseOrchestratorCallbacks & {
+    readonly logs: string[];
+    readonly progressShown: string[];
+    readonly progressHidden: number;
+    readonly metricsUpdated: number;
+    readonly vizNotified: string[];
+    readonly explorerLoads: Array<{ uri: string; cancelled: boolean }>;
+    readonly resolvedTypesPushed: number;
+    /** Gate for loadModelExplorer — if set, blocks until opened */
+    useExplorerGate(): { open: () => void };
+    /** Make next loadModelExplorer throw */
+    failNextExplorer(err: Error): void;
+    /** Set stats returned by getLastStats */
+    setStats(stats: { totalElements: number } | undefined): void;
+} {
+    const logs: string[] = [];
+    const progressShown: string[] = [];
+    let progressHiddenCount = 0;
+    let metricsUpdatedCount = 0;
+    const vizNotified: string[] = [];
+    const explorerLoads: Array<{ uri: string; cancelled: boolean }> = [];
+    let resolvedTypesPushedCount = 0;
+    let _gate: { promise: Promise<void>; open: () => void } | undefined;
+    let _failNext: Error | undefined;
+    let _stats: { totalElements: number } | undefined;
+
+    const cb: any = {
+        get logs() { return logs; },
+        get progressShown() { return progressShown; },
+        get progressHidden() { return progressHiddenCount; },
+        get metricsUpdated() { return metricsUpdatedCount; },
+        get vizNotified() { return vizNotified; },
+        get explorerLoads() { return explorerLoads; },
+        get resolvedTypesPushed() { return resolvedTypesPushedCount; },
+
+        useExplorerGate() {
+            const d = deferred();
+            _gate = { promise: d.promise, open: d.resolve };
+            return _gate;
+        },
+
+        failNextExplorer(err: Error) { _failNext = err; },
+
+        setStats(stats: { totalElements: number } | undefined) { _stats = stats; },
+
+        showProgress(fileName: string) { progressShown.push(fileName); },
+        hideProgress() { progressHiddenCount++; },
+
+        async loadModelExplorer(doc: vscode.TextDocument, token: vscode.CancellationToken) {
+            if (_failNext) {
+                const e = _failNext;
+                _failNext = undefined;
+                throw e;
+            }
+            if (_gate) {
+                const g = _gate;
+                _gate = undefined;
+                await g.promise;
+            }
+            explorerLoads.push({ uri: doc.uri.toString(), cancelled: token.isCancellationRequested });
+        },
+        async revealInWorkspaceExplorer() { /* no-op */ },
+        isWorkspaceMode: overrides?.isWorkspaceMode ?? (() => false),
+        getLastStats: () => _stats,
+
+        updateMetrics() { metricsUpdatedCount++; },
+        async updateServerStats() { /* no-op */ },
+        async pushResolvedTypes() { resolvedTypesPushedCount++; },
+        notifyVisualization(uri: vscode.Uri) { vizNotified.push(uri.toString()); },
+        log(msg: string) { logs.push(msg); },
+
+        ...overrides,
+    };
+    return cb;
+}
+
+/** Static editor provider for tests. */
+function staticEditors(editors: SysMLEditorInfo[], active?: SysMLEditorInfo): EditorProvider {
+    return {
+        getVisibleSysMLEditors: () => editors,
+        getActiveSysMLEditor: () => active,
+    };
+}
+
+/** No visible editors. */
+const noEditors: EditorProvider = staticEditors([]);
+
+/** Wait for setTimeout(0) chains to flush. */
+function flush(ms = 0): Promise<void> {
+    return new Promise(r => setTimeout(r, ms));
+}
+
+// ── E. requestParse debounce & cancellation ──────────────────────
+
+suite('ParseOrchestrator — requestParse', () => {
+
+    test('E1: single call triggers one parse after debounce', async () => {
+        const cb = createSpyCallbacks();
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.debounceMs = 20;
+
+        const doc = fakeDoc('file:///test.sysml');
+        orch.requestParse(doc);
+
+        // Immediately: progress shown, but no explorer load yet
+        assert.strictEqual(cb.progressShown.length, 1);
+        assert.strictEqual(cb.explorerLoads.length, 0);
+
+        await flush(50);
+
+        assert.strictEqual(cb.explorerLoads.length, 1);
+        assert.strictEqual(cb.explorerLoads[0].uri, 'file:///test.sysml');
+        assert.ok(cb.progressHidden >= 1, 'Progress should be hidden after parse');
+    });
+
+    test('E2: rapid calls — only last document parsed', async () => {
+        const cb = createSpyCallbacks();
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.debounceMs = 20;
+
+        orch.requestParse(fakeDoc('file:///a.sysml'));
+        orch.requestParse(fakeDoc('file:///b.sysml'));
+        orch.requestParse(fakeDoc('file:///c.sysml'));
+
+        await flush(50);
+
+        // Only the last document should have been loaded
+        assert.strictEqual(cb.explorerLoads.length, 1);
+        assert.ok(cb.explorerLoads[0].uri.includes('c.sysml'),
+            'Only the final document should be parsed');
+    });
+
+    test('E3: second requestParse cancels in-flight first', async () => {
+        const cb = createSpyCallbacks();
+        const gate = cb.useExplorerGate();
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.debounceMs = 5;
+
+        const doc1 = fakeDoc('file:///first.sysml');
+        orch.requestParse(doc1);
+
+        await flush(15); // Let debounce fire, now blocked on gate
+
+        // Second request while first is in-flight
+        const doc2 = fakeDoc('file:///second.sysml');
+        orch.requestParse(doc2);
+
+        // Release the gate for the first (already cancelled)
+        gate.open();
+        await flush(30);
+
+        // Should have loaded the second document
+        const lastLoad = cb.explorerLoads[cb.explorerLoads.length - 1];
+        assert.ok(lastLoad.uri.includes('second.sysml'));
+    });
+
+    test('E4: closed document skipped when debounce fires', async () => {
+        const cb = createSpyCallbacks();
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.debounceMs = 20;
+
+        const doc = fakeDoc('file:///closing.sysml');
+        orch.requestParse(doc);
+
+        // Close before debounce fires
+        doc.close();
+        await flush(50);
+
+        assert.strictEqual(cb.explorerLoads.length, 0,
+            'Closed document should not trigger explorer load');
+    });
+
+    test('E5: progress shown on requestParse, hidden after completion', async () => {
+        const cb = createSpyCallbacks();
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.debounceMs = 5;
+
+        orch.requestParse(fakeDoc('file:///test.sysml'));
+        assert.deepStrictEqual(cb.progressShown, ['test.sysml']);
+
+        await flush(30);
+        assert.ok(cb.progressHidden >= 1);
+    });
+
+    test('E6: skipProgress suppresses progress indicator', async () => {
+        const cb = createSpyCallbacks();
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.debounceMs = 5;
+
+        orch.requestParse(fakeDoc('file:///test.sysml'), { skipProgress: true });
+        assert.strictEqual(cb.progressShown.length, 0,
+            'Progress should not be shown with skipProgress');
+
+        await flush(30);
+    });
+
+    test('E7: model explorer error is non-critical — metrics + viz still run', async () => {
+        const cb = createSpyCallbacks();
+        cb.failNextExplorer(new Error('Explorer crashed'));
+        cb.setStats({ totalElements: 5 }); // pretend stats survived
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.debounceMs = 5;
+
+        orch.requestParse(fakeDoc('file:///test.sysml'));
+        await flush(30);
+
+        // Explorer load threw, but metrics should still update
+        assert.strictEqual(cb.metricsUpdated, 1,
+            'Metrics should update even when explorer throws');
+    });
+
+    test('E8: cancellation after model explorer skips feature inspector + viz', async () => {
+        const cb = createSpyCallbacks();
+        const gate = cb.useExplorerGate();
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.debounceMs = 5;
+
+        const doc = fakeDoc('file:///test.sysml');
+        orch.requestParse(doc);
+
+        await flush(15); // Debounce fires, now blocked on gate
+
+        // Second request cancels the first
+        orch.requestParse(fakeDoc('file:///other.sysml'));
+        gate.open();
+        await flush(30);
+
+        // The first parse was cancelled mid-flight.
+        // Check that viz notification is for the second document.
+        const vizForFirst = cb.vizNotified.filter(u => u.includes('test.sysml'));
+        assert.strictEqual(vizForFirst.length, 0,
+            'Cancelled parse should not notify visualization');
+    });
+
+    test('E9: isDebouncing and isParsing reflect state correctly', async () => {
+        const cb = createSpyCallbacks();
+        const gate = cb.useExplorerGate();
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.debounceMs = 20;
+
+        assert.strictEqual(orch.isDebouncing, false);
+        assert.strictEqual(orch.isParsing, false);
+
+        orch.requestParse(fakeDoc('file:///test.sysml'));
+
+        // During debounce wait
+        assert.strictEqual(orch.isDebouncing, true);
+        assert.strictEqual(orch.isParsing, true); // cancelSource created
+
+        await flush(30); // Debounce fires, now blocked on gate
+
+        // Debounce timer cleared, but parse in-flight
+        assert.strictEqual(orch.isDebouncing, false);
+
+        gate.open();
+        await flush(10);
+
+        assert.strictEqual(orch.isParsing, false);
+    });
+
+    test('E10: workspace mode calls revealInWorkspaceExplorer instead of loadDocument', async () => {
+        let revealCalled = false;
+        const cb = createSpyCallbacks({
+            isWorkspaceMode: () => true,
+            revealInWorkspaceExplorer: async () => { revealCalled = true; },
+        });
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.debounceMs = 5;
+
+        orch.requestParse(fakeDoc('file:///ws/test.sysml'));
+        await flush(30);
+
+        assert.ok(revealCalled, 'Should call revealInWorkspaceExplorer in workspace mode');
+        assert.strictEqual(cb.explorerLoads.length, 0,
+            'Should not call loadModelExplorer in workspace mode');
+    });
+});
+
+// ── F. notifyServerParseDone guards ──────────────────────────────
+
+suite('ParseOrchestrator — notifyServerParseDone', () => {
+
+    test('F1: no visible editors — no-op', async () => {
+        const cb = createSpyCallbacks();
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.parseDoneDebounceMs = 5;
+
+        orch.notifyServerParseDone('file:///test.sysml');
+        await flush(30);
+
+        assert.strictEqual(cb.explorerLoads.length, 0);
+        assert.strictEqual(cb.logs.filter(l => l.includes('re-parsing')).length, 0);
+    });
+
+    test('F2: matching URI editor found and re-parsed', async () => {
+        const cb = createSpyCallbacks();
+        const doc = fakeDoc('file:///match.sysml');
+        const editors = staticEditors([{ uri: doc.uri.toString(), document: doc }]);
+        const orch = new ParseOrchestrator(cb, editors);
+        orch.parseDoneDebounceMs = 5;
+        orch.debounceMs = 5;
+
+        orch.notifyServerParseDone(doc.uri.toString());
+        await flush(50);
+
+        assert.ok(cb.logs.some(l => l.includes('re-parsing match.sysml')));
+        assert.strictEqual(cb.explorerLoads.length, 1);
+    });
+
+    test('F3: fallback to active editor when URI has no match', async () => {
+        const cb = createSpyCallbacks();
+        const active = fakeDoc('file:///active.sysml');
+        const editors = staticEditors(
+            [{ uri: active.uri.toString(), document: active }],
+            { uri: active.uri.toString(), document: active },
+        );
+        const orch = new ParseOrchestrator(cb, editors);
+        orch.parseDoneDebounceMs = 5;
+        orch.debounceMs = 5;
+
+        orch.notifyServerParseDone('file:///nonexistent.sysml');
+        await flush(50);
+
+        assert.ok(cb.logs.some(l => l.includes('re-parsing active.sysml')));
+    });
+
+    test('F4: skip when debounce pending', async () => {
+        const cb = createSpyCallbacks();
+        const doc = fakeDoc('file:///test.sysml');
+        const editors = staticEditors([{ uri: doc.uri.toString(), document: doc }]);
+        const orch = new ParseOrchestrator(cb, editors);
+        orch.debounceMs = 500; // Long debounce so it's still pending
+        orch.parseDoneDebounceMs = 5;
+
+        // Start a parse (debounce will be pending for 500ms)
+        orch.requestParse(doc);
+
+        // Now server says it's done
+        orch.notifyServerParseDone(doc.uri.toString());
+        await flush(30);
+
+        assert.ok(cb.logs.some(l => l.includes('skipping — parse already in progress')));
+    });
+
+    test('F5: skip when parse in-flight', async () => {
+        const cb = createSpyCallbacks();
+        const gate = cb.useExplorerGate();
+        const doc = fakeDoc('file:///test.sysml');
+        const editors = staticEditors([{ uri: doc.uri.toString(), document: doc }]);
+        const orch = new ParseOrchestrator(cb, editors);
+        orch.debounceMs = 5;
+        orch.parseDoneDebounceMs = 5;
+
+        // Start parse, let debounce fire, block on gate (in-flight)
+        orch.requestParse(doc);
+        await flush(15);
+
+        orch.notifyServerParseDone(doc.uri.toString());
+        await flush(30);
+
+        gate.open();
+        await flush(30);
+
+        assert.ok(cb.logs.some(l => l.includes('skipping — parse already in progress')));
+    });
+
+    test('F6: skip when explorer already has elements', async () => {
+        const cb = createSpyCallbacks();
+        cb.setStats({ totalElements: 10 });
+        const doc = fakeDoc('file:///test.sysml');
+        const editors = staticEditors([{ uri: doc.uri.toString(), document: doc }]);
+        const orch = new ParseOrchestrator(cb, editors);
+        orch.parseDoneDebounceMs = 5;
+
+        orch.notifyServerParseDone(doc.uri.toString());
+        await flush(30);
+
+        assert.ok(cb.logs.some(l => l.includes('skipping re-parse — explorer already has 10 elements')));
+        assert.strictEqual(cb.explorerLoads.length, 0);
+    });
+
+    test('F7: cooldown suppresses rapid-fire', async () => {
+        const cb = createSpyCallbacks();
+        const doc = fakeDoc('file:///test.sysml');
+        const editors = staticEditors([{ uri: doc.uri.toString(), document: doc }]);
+        const orch = new ParseOrchestrator(cb, editors);
+        orch.parseDoneDebounceMs = 5;
+        orch.debounceMs = 5;
+        orch.parseDoneCooldownMs = 200;
+
+        // First notification — should fire
+        orch.notifyServerParseDone(doc.uri.toString());
+        await flush(50);
+        assert.ok(cb.logs.some(l => l.includes('re-parsing')));
+
+        // Wait for the requestParse debounce to complete so isDebouncing/isParsing clear
+        await flush(50);
+
+        // Second notification within cooldown — should be suppressed
+        orch.notifyServerParseDone(doc.uri.toString());
+        await flush(30);
+        assert.ok(cb.logs.some(l => l.includes('cooldown')));
+    });
+
+    test('F8: after cooldown expires, re-parse fires again', async () => {
+        const cb = createSpyCallbacks();
+        const doc = fakeDoc('file:///test.sysml');
+        const editors = staticEditors([{ uri: doc.uri.toString(), document: doc }]);
+        const orch = new ParseOrchestrator(cb, editors);
+        orch.parseDoneDebounceMs = 5;
+        orch.debounceMs = 5;
+        orch.parseDoneCooldownMs = 50;
+
+        orch.notifyServerParseDone(doc.uri.toString());
+        await flush(40);
+
+        // Wait for cooldown to expire
+        await flush(60);
+
+        const logsBefore = cb.logs.filter(l => l.includes('re-parsing')).length;
+        orch.notifyServerParseDone(doc.uri.toString());
+        await flush(40);
+
+        const logsAfter = cb.logs.filter(l => l.includes('re-parsing')).length;
+        assert.ok(logsAfter > logsBefore, 'Should re-parse after cooldown expires');
+    });
+
+    test('F9: parseDone debounce coalesces rapid notifications', async () => {
+        const cb = createSpyCallbacks();
+        const doc = fakeDoc('file:///test.sysml');
+        const editors = staticEditors([{ uri: doc.uri.toString(), document: doc }]);
+        const orch = new ParseOrchestrator(cb, editors);
+        orch.parseDoneDebounceMs = 30;
+        orch.debounceMs = 5;
+
+        // Fire 5 notifications in quick succession
+        for (let i = 0; i < 5; i++) {
+            orch.notifyServerParseDone(doc.uri.toString());
+        }
+        await flush(80);
+
+        const reparses = cb.logs.filter(l => l.includes('re-parsing'));
+        assert.strictEqual(reparses.length, 1,
+            'Rapid notifications should coalesce into one re-parse');
+    });
+});
+
+// ── G. cancelAll ─────────────────────────────────────────────────
+
+suite('ParseOrchestrator — cancelAll', () => {
+
+    test('G1: cancels pending debounce', async () => {
+        const cb = createSpyCallbacks();
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.debounceMs = 500;
+
+        orch.requestParse(fakeDoc('file:///test.sysml'));
+        assert.ok(orch.isDebouncing);
+
+        orch.cancelAll();
+        assert.ok(!orch.isDebouncing, 'Debounce should be cleared');
+
+        await flush(600);
+        assert.strictEqual(cb.explorerLoads.length, 0,
+            'No explorer load should have fired');
+    });
+
+    test('G2: cancels in-flight parse', async () => {
+        const cb = createSpyCallbacks();
+        const gate = cb.useExplorerGate();
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.debounceMs = 5;
+
+        orch.requestParse(fakeDoc('file:///test.sysml'));
+        await flush(15); // Let debounce fire
+
+        assert.ok(orch.isParsing);
+        orch.cancelAll();
+        assert.ok(!orch.isParsing, 'Active parse should be cancelled');
+
+        gate.open();
+        await flush(30);
+
+        // Should not have reached viz notification
+        assert.strictEqual(cb.vizNotified.length, 0);
+    });
+
+    test('G3: clearsParseDone timer', async () => {
+        const cb = createSpyCallbacks();
+        const doc = fakeDoc('file:///test.sysml');
+        const editors = staticEditors([{ uri: doc.uri.toString(), document: doc }]);
+        const orch = new ParseOrchestrator(cb, editors);
+        orch.parseDoneDebounceMs = 500;
+
+        orch.notifyServerParseDone(doc.uri.toString());
+        orch.cancelAll();
+
+        await flush(600);
+        assert.strictEqual(cb.explorerLoads.length, 0,
+            'ParseDone should not fire after cancelAll');
+    });
+
+    test('G4: cancelAll hides progress', () => {
+        const cb = createSpyCallbacks();
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.debounceMs = 500;
+
+        orch.requestParse(fakeDoc('file:///test.sysml'));
+        const hiddenBefore = cb.progressHidden;
+
+        orch.cancelAll();
+        assert.ok(cb.progressHidden > hiddenBefore,
+            'cancelAll should hide progress');
+    });
+});
+
+// ── H. Integration: full parse → serverDone flow ─────────────────
+
+suite('ParseOrchestrator — Integration flows', () => {
+
+    test('H1: cold start: parse returns 0 → server done → re-parse fires', async () => {
+        const cb = createSpyCallbacks();
+        // Simulate cold start: no stats initially
+        cb.setStats(undefined);
+
+        const doc = fakeDoc('file:///cold.sysml');
+        const editors = staticEditors(
+            [{ uri: doc.uri.toString(), document: doc }],
+            { uri: doc.uri.toString(), document: doc },
+        );
+        const orch = new ParseOrchestrator(cb, editors);
+        orch.debounceMs = 5;
+        orch.parseDoneDebounceMs = 5;
+        orch.parseDoneCooldownMs = 100;
+
+        // Initial parse
+        orch.requestParse(doc);
+        await flush(30);
+
+        const loadsBefore = cb.explorerLoads.length;
+
+        // Server signals done
+        orch.notifyServerParseDone(doc.uri.toString());
+        await flush(50);
+
+        assert.ok(cb.explorerLoads.length > loadsBefore,
+            'Server done should trigger re-parse when stats are empty');
+        assert.ok(cb.logs.some(l => l.includes('re-parsing')));
+    });
+
+    test('H2: hot start: parse returns data → server done → skipped', async () => {
+        const cb = createSpyCallbacks();
+        cb.setStats({ totalElements: 5 });
+
+        const doc = fakeDoc('file:///hot.sysml');
+        const editors = staticEditors(
+            [{ uri: doc.uri.toString(), document: doc }],
+            { uri: doc.uri.toString(), document: doc },
+        );
+        const orch = new ParseOrchestrator(cb, editors);
+        orch.debounceMs = 5;
+        orch.parseDoneDebounceMs = 5;
+
+        orch.requestParse(doc);
+        await flush(30);
+
+        const loadsBefore = cb.explorerLoads.length;
+
+        orch.notifyServerParseDone(doc.uri.toString());
+        await flush(30);
+
+        assert.strictEqual(cb.explorerLoads.length, loadsBefore,
+            'Should not re-parse when explorer already has data');
+        assert.ok(cb.logs.some(l => l.includes('skipping re-parse')));
+    });
+
+    test('H3: edit during parse → new parse replaces old', async () => {
+        const cb = createSpyCallbacks();
+        const gate = cb.useExplorerGate();
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.debounceMs = 5;
+
+        const doc = fakeDoc('file:///editing.sysml');
+        // First "keystroke"
+        orch.requestParse(doc);
+        await flush(15); // Let debounce fire, block on gate
+
+        // Second "keystroke" — cancels first
+        const doc2 = fakeDoc('file:///editing.sysml');
+        orch.requestParse(doc2);
+
+        gate.open();
+        await flush(30);
+
+        // The second parse should have won
+        const lastLoad = cb.explorerLoads[cb.explorerLoads.length - 1];
+        assert.ok(lastLoad, 'Should have at least one load');
+    });
+
+    test('H4: file switch during parse → old cancelled, new starts', async () => {
+        const cb = createSpyCallbacks();
+        const gate = cb.useExplorerGate();
+        const orch = new ParseOrchestrator(cb, noEditors);
+        orch.debounceMs = 5;
+
+        // Open file A
+        orch.requestParse(fakeDoc('file:///a.sysml'));
+        await flush(15); // In-flight on gate
+
+        // Switch to file B — cancels A
+        orch.requestParse(fakeDoc('file:///b.sysml'));
+        gate.open();
+        await flush(30);
+
+        // File B's parse should have completed
+        const lastLoad = cb.explorerLoads[cb.explorerLoads.length - 1];
+        assert.ok(lastLoad.uri.includes('b.sysml'),
+            'Switched file should be the one that completes');
+    });
+
+    test('H5: notifyServerParseDone during active parse is skipped', async () => {
+        const cb = createSpyCallbacks();
+        const gate = cb.useExplorerGate();
+        const doc = fakeDoc('file:///test.sysml');
+        const editors = staticEditors([{ uri: doc.uri.toString(), document: doc }]);
+        const orch = new ParseOrchestrator(cb, editors);
+        orch.debounceMs = 5;
+        orch.parseDoneDebounceMs = 5;
+
+        // Start parse, block on gate
+        orch.requestParse(doc);
+        await flush(15);
+
+        // Server done while parse in-flight
+        orch.notifyServerParseDone(doc.uri.toString());
+        await flush(30);
+
+        assert.ok(cb.logs.some(l => l.includes('skipping — parse already in progress')),
+            'Should skip re-parse when existing parse is in-flight');
+
+        gate.open();
+        await flush(30);
+    });
+
+    test('H6: multiple serverDone within cooldown — only first triggers re-parse', async () => {
+        const cb = createSpyCallbacks();
+        const doc = fakeDoc('file:///test.sysml');
+        const editors = staticEditors([{ uri: doc.uri.toString(), document: doc }]);
+        const orch = new ParseOrchestrator(cb, editors);
+        orch.debounceMs = 5;
+        orch.parseDoneDebounceMs = 5;
+        orch.parseDoneCooldownMs = 500;
+
+        // First serverDone
+        orch.notifyServerParseDone(doc.uri.toString());
+        await flush(50);
+
+        // Wait for parse to complete
+        await flush(30);
+
+        // Second serverDone within cooldown
+        orch.notifyServerParseDone(doc.uri.toString());
+        await flush(30);
+
+        // Third serverDone within cooldown
+        orch.notifyServerParseDone(doc.uri.toString());
+        await flush(30);
+
+        const reparses = cb.logs.filter(l => l.includes('re-parsing'));
+        assert.strictEqual(reparses.length, 1,
+            'Only first serverDone should trigger re-parse within cooldown');
+
+        const cooldowns = cb.logs.filter(l => l.includes('cooldown'));
+        assert.ok(cooldowns.length >= 1, 'Subsequent should be suppressed by cooldown');
+    });
+
+    test('H7: cancelAll during serverDone debounce prevents re-parse', async () => {
+        const cb = createSpyCallbacks();
+        const doc = fakeDoc('file:///test.sysml');
+        const editors = staticEditors([{ uri: doc.uri.toString(), document: doc }]);
+        const orch = new ParseOrchestrator(cb, editors);
+        orch.parseDoneDebounceMs = 100;
+
+        orch.notifyServerParseDone(doc.uri.toString());
+        // Cancel before the 100ms debounce fires
+        orch.cancelAll();
+        await flush(150);
+
+        assert.strictEqual(cb.explorerLoads.length, 0,
+            'cancelAll should prevent the serverDone re-parse');
+    });
+});


### PR DESCRIPTION
- LSP 0.10.0
- Validate progress indicators during parse requests and the effect of the skipProgress option.
- Test model explorer error handling and its impact on metrics and visualization notifications.
- Create tests for notifyServerParseDone guards, including scenarios for visible editors, matching URIs, and debounce conditions.
- Add tests for cancelAll functionality, ensuring it cancels pending debounces and in-flight parses, and clears timers.
- Integrate tests for the full parse to server done flow, covering cold and hot starts, edits during parses, and multiple server notifications.