### PR TITLE
feat: Update dependencies and enhance state transition extraction

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
   "name": "SysML v2 Extension",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:22",
   "features": {},
-  "postCreateCommand": "npm install --ignore-scripts",
+  "remoteUser": "node",
+  "postCreateCommand": "sudo chown -R node:node /workspaces/VSCode_SysML_Extension && npm install --ignore-scripts",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -36,7 +36,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, unit-tests]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, unit-tests]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
             echo "REF=${GITHUB_REF}" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ steps.ref.outputs.REF }}
 
@@ -65,7 +65,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: refs/tags/${{ steps.tag.outputs.TAG }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **State Transition View now renders transition edges** ([#60](https://github.com/daltskin/VSCode_SysML_Extension/issues/60)) — transition source/target (and the `accept` trigger as edge label) are recovered from the SysML source, covering inline and named/multi-line forms plus `then`-succession chains (`state idle; then state active;`). Undeclared transition targets are synthesized as nodes, and the `entry; then …` transition renders as an initial pseudostate (`[*] → firstState`).
+- **State Transition View layout** — defaults to top-down flow, the initial pseudostate arrow connects flush to the start circle, and isolated states sit at the bottom.
+
+### Changed
+
+- **Raised minimum VS Code version to 1.125.0** — `engines.vscode` and `@types/vscode` bumped in lock-step.
+- **Updated npm dependencies and resolved 2 high-severity advisories** (`form-data` → 4.0.6, `undici` → 7.28.0, via `@vscode/vsce`); `npm audit` now clean. Clears Dependabot PRs #52, #54, #55, #58, #59.
+- **Bumped `actions/checkout` v6 → v7** in CI/release workflows (Dependabot PR #56).
+
 ## [0.41.0]
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,26 +10,26 @@
       "license": "MIT",
       "dependencies": {
         "elkjs": "^0.11.0",
-        "sysml-v2-lsp": "^0.22.0",
-        "vscode-languageclient": "10.0.0"
+        "sysml-v2-lsp": "^0.23.0",
+        "vscode-languageclient": "^10.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.6.0",
-        "@types/vscode": "^1.118.0",
-        "@typescript-eslint/eslint-plugin": "^8.59.1",
-        "@typescript-eslint/parser": "^8.58.2",
-        "@vscode/test-electron": "^2.4.1",
-        "@vscode/test-web": "^0.0.80",
-        "@vscode/vsce": "^3.9.1",
+        "@types/node": "^26.1.0",
+        "@types/vscode": "^1.125.0",
+        "@typescript-eslint/eslint-plugin": "^8.62.1",
+        "@typescript-eslint/parser": "^8.62.1",
+        "@vscode/test-electron": "^3.0.0",
+        "@vscode/test-web": "^0.0.81",
+        "@vscode/vsce": "^3.9.2",
         "c8": "^11.0.0",
         "cytoscape": "^3.33.3",
         "cytoscape-elk": "^2.3.0",
         "cytoscape-svg": "^0.4.0",
         "d3": "^7.9.0",
         "esbuild": "^0.28.1",
-        "eslint": "^10.3.0",
+        "eslint": "^10.6.0",
         "glob": "^13.0.0",
         "mocha": "^11.0.0",
         "rimraf": "^6.0.1",
@@ -37,7 +37,7 @@
         "typescript": "^6.0.2"
       },
       "engines": {
-        "vscode": "^1.118.0"
+        "vscode": "^1.125.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -1010,14 +1010,14 @@
       }
     },
     "node_modules/@playwright/browser-chromium": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.60.0.tgz",
-      "integrity": "sha512-0ND2pbNWKJYwhlA1LNaDC3DP2x7eguQkQF7Ga7XAlJV0AFieqYNRw/E+gaY9BpSFr1TYwfwXQv1bHq5AK9nbvA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.61.1.tgz",
+      "integrity": "sha512-t3/zE0i9gik5R/NpRs7G2Xo/6NPeABW6ReplGdtkeWeAkaV764CgFgoKjJo21D2xgjnvDvRYubqBUu4xl0VCqA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.1"
       },
       "engines": {
         "node": ">=18"
@@ -1358,13 +1358,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -1382,24 +1382,24 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.120.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
-      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
-      "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
+      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/type-utils": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/type-utils": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1412,22 +1412,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.60.1",
+        "@typescript-eslint/parser": "^8.62.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
-      "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
+      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1443,14 +1443,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
-      "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.60.1",
-        "@typescript-eslint/types": "^8.60.1",
+        "@typescript-eslint/tsconfig-utils": "^8.62.1",
+        "@typescript-eslint/types": "^8.62.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1465,14 +1465,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
-      "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1"
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1483,9 +1483,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
-      "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1500,15 +1500,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
-      "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
+      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1525,9 +1525,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1539,16 +1539,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
-      "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.60.1",
-        "@typescript-eslint/tsconfig-utils": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/project-service": "8.62.1",
+        "@typescript-eslint/tsconfig-utils": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1567,16 +1567,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
-      "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1"
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1591,13 +1591,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
-      "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/types": "8.62.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1637,9 +1637,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.0.0.tgz",
+      "integrity": "sha512-TY5mC7aAjxSLDXsyjhrG8cJHgc/HLdiE5lvtW7hABYQrY24Qwozzr5UoO3HiuAM4Hzz4b7K/eZlwrCILj94CcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1650,30 +1650,30 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/test-web": {
-      "version": "0.0.80",
-      "resolved": "https://registry.npmjs.org/@vscode/test-web/-/test-web-0.0.80.tgz",
-      "integrity": "sha512-QgsRPp8IuPcdbUdVtqQkFN/sGd+6cr6g0ENEVFOHwJbQqZtJSiZD5w0e6tgmoeq9nBjNqZCq87OO1GkwFHkPyw==",
+      "version": "0.0.81",
+      "resolved": "https://registry.npmjs.org/@vscode/test-web/-/test-web-0.0.81.tgz",
+      "integrity": "sha512-qAYNX1mf4hE0L3T/186J8AH+Z7Inm81OHMACkkyKE2J6HJZlXou0OgABkSvd8gt0BiPjI+V+xkduAaQ8Kcjexg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@koa/cors": "^5.0.0",
-        "@koa/router": "^15.3.0",
-        "@playwright/browser-chromium": "^1.58.2",
+        "@koa/router": "^15.6.0",
+        "@playwright/browser-chromium": "^1.61.0",
         "gunzip-maybe": "^1.4.2",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "koa": "^3.1.2",
+        "http-proxy-agent": "^9.1.0",
+        "https-proxy-agent": "^9.1.0",
+        "koa": "^3.2.1",
         "koa-morgan": "^1.0.1",
         "koa-mount": "^4.2.0",
         "koa-static": "^5.0.0",
         "minimist": "^1.2.8",
-        "playwright": "^1.58.2",
-        "tar-fs": "^3.1.1",
-        "tinyglobby": "^0.2.15",
+        "playwright": "^1.61.0",
+        "tar-fs": "^3.1.2",
+        "tinyglobby": "^0.2.17",
         "vscode-uri": "^3.1.0"
       },
       "bin": {
@@ -1681,6 +1681,46 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@vscode/test-web/node_modules/agent-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vscode/test-web/node_modules/http-proxy-agent": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vscode/test-web/node_modules/https-proxy-agent": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vscode/vsce": {
@@ -3739,11 +3779,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
-      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4148,17 +4191,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -6361,13 +6404,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6380,9 +6423,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6495,6 +6538,24 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/proxy-agent-negotiate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+      "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "kerberos": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "kerberos": {
+          "optional": true
+        }
+      }
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -7385,9 +7446,9 @@
       }
     },
     "node_modules/sysml-v2-lsp": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/sysml-v2-lsp/-/sysml-v2-lsp-0.22.0.tgz",
-      "integrity": "sha512-wjVgwdSnhMJqKFZ55eg9CKQZXDysWD7WEfvI0GFtRZMWZlLn9bmWgGFtyRbfyRdDbXETTJN2iHc96qF1shHAKg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/sysml-v2-lsp/-/sysml-v2-lsp-0.23.0.tgz",
+      "integrity": "sha512-+eMGOBe6aJFNk52eT6kUPVUi/AfRA/wwcHXz1Ob3BxhbR+wdzGrRONvy0hpjoIalje4FQb136nLqk83uV7drYA==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -7858,9 +7919,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7868,9 +7929,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7989,23 +8050,23 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0.tgz",
-      "integrity": "sha512-+VvMmQPJhtvJ+8O+zu2JKIRiLxXF8NW7krWgyMGeOHrp4Cn23T5hc0v2LknNeopDOB70wghHAds7mKtcZ0I4Sg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.0.0.tgz",
-      "integrity": "sha512-3yRHFkktZQCCg8ehHnD2Z4DZ4mZ17FNo8bxM4OFt8wtpxNBAOZGHmpbIflZSkicvCxi+ozuWntbdeWiY0gP77w==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.1.0.tgz",
+      "integrity": "sha512-XXRx6lqVitQy/oOLr9MfNYRG+MbQkhXkDaxbQMiKxEm8zZNfheRFUKNb8UYNh2stn9btl2wQM5wZFJjJvoc+jA==",
       "license": "MIT",
       "dependencies": {
         "minimatch": "^10.2.5",
         "semver": "^7.8.1",
-        "vscode-languageserver-protocol": "3.18.0",
+        "vscode-languageserver-protocol": "3.18.2",
         "vscode-languageserver-textdocument": "1.0.13"
       },
       "engines": {
@@ -8013,12 +8074,12 @@
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.0.tgz",
-      "integrity": "sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "9.0.0",
+        "vscode-jsonrpc": "9.0.1",
         "vscode-languageserver-types": "3.18.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/daltskin/VSCode_SysML_Extension.git"
   },
   "engines": {
-    "vscode": "^1.118.0"
+    "vscode": "^1.125.0"
   },
   "main": "./out/extension.js",
   "browser": "./dist/web/extension.js",
@@ -479,20 +479,20 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.6.0",
-    "@types/vscode": "^1.118.0",
-    "@typescript-eslint/eslint-plugin": "^8.59.1",
-    "@typescript-eslint/parser": "^8.58.2",
-    "@vscode/test-electron": "^2.4.1",
-    "@vscode/test-web": "^0.0.80",
-    "@vscode/vsce": "^3.9.1",
+    "@types/node": "^26.1.0",
+    "@types/vscode": "^1.125.0",
+    "@typescript-eslint/eslint-plugin": "^8.62.1",
+    "@typescript-eslint/parser": "^8.62.1",
+    "@vscode/test-electron": "^3.0.0",
+    "@vscode/test-web": "^0.0.81",
+    "@vscode/vsce": "^3.9.2",
     "c8": "^11.0.0",
     "cytoscape": "^3.33.3",
     "cytoscape-elk": "^2.3.0",
     "cytoscape-svg": "^0.4.0",
     "d3": "^7.9.0",
     "esbuild": "^0.28.1",
-    "eslint": "^10.3.0",
+    "eslint": "^10.6.0",
     "glob": "^13.0.0",
     "mocha": "^11.0.0",
     "rimraf": "^6.0.1",
@@ -501,8 +501,8 @@
   },
   "dependencies": {
     "elkjs": "^0.11.0",
-    "sysml-v2-lsp": "^0.22.0",
-    "vscode-languageclient": "10.0.0"
+    "sysml-v2-lsp": "^0.23.0",
+    "vscode-languageclient": "^10.1.0"
   },
   "overrides": {
     "brace-expansion": "^5.0.5",

--- a/src/test/visualizationPanel.test.ts
+++ b/src/test/visualizationPanel.test.ts
@@ -182,3 +182,155 @@ suite('Visualization Panel Test Suite', () => {
         assert.ok(true, 'Multiple files visualized without error');
     });
 });
+
+suite('State Transition Extraction', () => {
+    const { VisualizationPanel } = require('../visualization/visualizationPanel');
+
+    test('extracts named multi-line transitions (issue #60)', () => {
+        const src = `package TrafficLight {
+    state def SignalStateMachine {
+        entry; then Red;
+        state Red;
+        transition red_to_green
+            first Red
+            accept Timer
+            then Green;
+        state Green;
+    }
+}`;
+        const trans = VisualizationPanel.extractTransitionRelationships(src);
+        assert.strictEqual(trans.length, 1);
+        assert.deepStrictEqual(trans[0], {
+            type: 'transition',
+            source: 'Red',
+            target: 'Green',
+            name: 'Timer',
+        });
+    });
+
+    test('extracts inline transitions without a name', () => {
+        const src = `state def M {
+        state idle;
+        state driving;
+        transition first idle then driving;
+        transition first driving then idle;
+    }`;
+        const trans = VisualizationPanel.extractTransitionRelationships(src);
+        assert.strictEqual(trans.length, 2);
+        assert.strictEqual(trans[0].source, 'idle');
+        assert.strictEqual(trans[0].target, 'driving');
+        assert.strictEqual(trans[0].name, '');
+        assert.strictEqual(trans[1].source, 'driving');
+        assert.strictEqual(trans[1].target, 'idle');
+    });
+
+    test('handles qualified and quoted state references', () => {
+        const src = `transition first A::B accept Sig then 'My State';`;
+        const trans = VisualizationPanel.extractTransitionRelationships(src);
+        assert.strictEqual(trans.length, 1);
+        assert.strictEqual(trans[0].source, 'A::B');
+        assert.strictEqual(trans[0].target, 'My State');
+        assert.strictEqual(trans[0].name, 'Sig');
+    });
+
+    test('ignores transition keywords inside comments', () => {
+        const src = `// transition first ghost then phantom;
+    /* transition first x then y; */
+    transition first real1 then real2;`;
+        const trans = VisualizationPanel.extractTransitionRelationships(src);
+        assert.strictEqual(trans.length, 1);
+        assert.strictEqual(trans[0].source, 'real1');
+        assert.strictEqual(trans[0].target, 'real2');
+    });
+
+    test('returns empty array when there are no transitions', () => {
+        const trans = VisualizationPanel.extractTransitionRelationships('part def Engine;');
+        assert.deepStrictEqual(trans, []);
+    });
+
+    test('extracts both transitions including an undeclared target', () => {
+        const src = `package TrafficLight {
+    state def SignalStateMachine {
+        entry; then Red;
+        state Red;
+        transition red_to_green
+            first Red
+            accept Timer
+            then Green;
+        state Green;
+        transition green_to_yellow
+            first Green
+            accept Caution
+            then Yellow;
+        state Flashing;
+    }
+}`;
+        const trans = VisualizationPanel.extractTransitionRelationships(src);
+        assert.strictEqual(trans.length, 2);
+        // Second transition targets Yellow, which is never declared as a
+        // `state` — it must still be extracted so the view can synthesize it.
+        assert.deepStrictEqual(trans[1], {
+            type: 'transition',
+            source: 'Green',
+            target: 'Yellow',
+            name: 'Caution',
+        });
+    });
+
+    test('extracts the initial (entry) transition as an initial pseudostate', () => {
+        const src = `state def M {
+        entry; then Initialization;
+        state Initialization;
+    }`;
+        const initial = VisualizationPanel.extractInitialTransitions(src);
+        assert.strictEqual(initial.length, 1);
+        assert.strictEqual(initial[0].source, VisualizationPanel.INITIAL_PSEUDOSTATE);
+        assert.strictEqual(initial[0].target, 'Initialization');
+    });
+
+    test('extracts entry transition written without a semicolon', () => {
+        const initial = VisualizationPanel.extractInitialTransitions('state def M { entry then idle; }');
+        assert.strictEqual(initial.length, 1);
+        assert.strictEqual(initial[0].target, 'idle');
+    });
+
+    test('returns no initial transition when there is no entry point', () => {
+        const initial = VisualizationPanel.extractInitialTransitions('transition first a then b;');
+        assert.deepStrictEqual(initial, []);
+    });
+
+    test('extracts then-succession chains between states', () => {
+        const src = `state def OperatingStates {
+        state idle;
+        then state active;
+        then state fault;
+    }`;
+        const succ = VisualizationPanel.extractSuccessionTransitions(src);
+        assert.strictEqual(succ.length, 2);
+        assert.deepStrictEqual(succ[0], { type: 'transition', source: 'idle', target: 'active', name: '' });
+        assert.deepStrictEqual(succ[1], { type: 'transition', source: 'active', target: 'fault', name: '' });
+    });
+
+    test('ignores action-flow successions (then action …)', () => {
+        const src = `action def Run {
+        first start;
+        then action initialize;
+        then action monitor;
+        then done;
+    }`;
+        assert.deepStrictEqual(VisualizationPanel.extractSuccessionTransitions(src), []);
+    });
+
+    test('does not treat entry or explicit transitions as successions', () => {
+        const src = `state def M {
+        entry; then idle;
+        state idle;
+        transition first idle then busy;
+        state busy;
+    }`;
+        // entry→idle is an initial transition, idle→busy is an explicit
+        // transition — neither should appear as a plain succession here.
+        assert.deepStrictEqual(VisualizationPanel.extractSuccessionTransitions(src), []);
+    });
+});
+

--- a/src/visualization/visualizationPanel.ts
+++ b/src/visualization/visualizationPanel.ts
@@ -296,6 +296,44 @@ export class VisualizationPanel {
                 if (result.activityDiagrams) { allActivityDiagrams.push(...(result.activityDiagrams as unknown[])); }
             }
 
+            // The LSP emits `transition` elements but does not populate their
+            // source/target (the `first … then …` targets), so the State
+            // Transition View never receives any edges.  Recover the
+            // transitions directly from the document text and inject them as
+            // `transition` relationships that the webview's state view
+            // already knows how to render.  De-duplicate against anything the
+            // LSP may provide in future so we never double-draw an edge.
+            const existingTransitionKeys = new Set(
+                allRelationships
+                    .map(r => r as { type?: string; source?: string; target?: string })
+                    .filter(r => String(r.type ?? '').toLowerCase().includes('transition'))
+                    .map(r => `${r.source}->${r.target}`),
+            );
+            const texts = await Promise.all(urisToQuery.map(uri => this._getTextForUri(uri)));
+            for (const text of texts) {
+                for (const rel of VisualizationPanel.extractTransitionRelationships(text)) {
+                    const key = `${rel.source}->${rel.target}`;
+                    if (!existingTransitionKeys.has(key)) {
+                        existingTransitionKeys.add(key);
+                        allRelationships.push(rel);
+                    }
+                }
+                for (const rel of VisualizationPanel.extractInitialTransitions(text)) {
+                    const key = `${rel.source}->${rel.target}`;
+                    if (!existingTransitionKeys.has(key)) {
+                        existingTransitionKeys.add(key);
+                        allRelationships.push(rel);
+                    }
+                }
+                for (const rel of VisualizationPanel.extractSuccessionTransitions(text)) {
+                    const key = `${rel.source}->${rel.target}`;
+                    if (!existingTransitionKeys.has(key)) {
+                        existingTransitionKeys.add(key);
+                        allRelationships.push(rel);
+                    }
+                }
+            }
+
             // SysML v2 allows the same package to be declared across multiple
             // files — their members merge into a single namespace.  Coalesce
             // same-named package DTOs so the webview sees one unified tree.
@@ -323,6 +361,203 @@ export class VisualizationPanel {
             // webview doesn't stay stuck on "Parsing SysML model...".
             this.postMessageSafe({ command: 'hideLoading' });
         }
+    }
+
+    /**
+     * Return the text for a queried URI.  Uses the already-open primary
+     * document when possible, otherwise opens the document on demand
+     * (folder-level visualization queries multiple files).
+     */
+    private async _getTextForUri(uriStr: string): Promise<string> {
+        if (uriStr === this._document.uri.toString()) {
+            return this._document.getText();
+        }
+        try {
+            const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(uriStr));
+            return doc.getText();
+        } catch {
+            return '';
+        }
+    }
+
+    /**
+     * Extract state-machine transitions from raw SysML source.
+     *
+     * The LSP recognises `transition` elements but does not currently expose
+     * their `first … [accept …] then …` source/target, so the State
+     * Transition View has no edges to draw.  This lightweight scanner
+     * recovers those edges directly from the text, supporting both the
+     * inline form (`transition first S then T;`) and the named/multi-line
+     * form (`transition name first S accept Trig then T;`).  The optional
+     * `accept` trigger becomes the transition label.
+     */
+    public static extractTransitionRelationships(
+        text: string,
+    ): { type: string; source: string; target: string; name: string }[] {
+        // Strip comments so keywords inside them are never matched.
+        const cleaned = text
+            .replace(/\/\/[^\n]*/g, ' ')
+            .replace(/\/\*[\s\S]*?\*\//g, ' ');
+
+        // A reference is either a single-quoted name (may contain spaces) or
+        // a plain/qualified/dotted identifier.
+        const ref = "('[^']*'|[A-Za-z_][\\w.:]*)";
+        const firstRe = new RegExp(`\\bfirst\\s+${ref}`);
+        const thenRe = new RegExp(`\\bthen\\s+${ref}`);
+        const acceptRe = new RegExp(`\\baccept\\s+${ref}`);
+
+        const stripQuotes = (s: string): string =>
+            s.startsWith("'") && s.endsWith("'") ? s.slice(1, -1) : s;
+
+        const out: { type: string; source: string; target: string; name: string }[] = [];
+        // Each transition declaration runs from the `transition` keyword to
+        // the terminating semicolon.
+        const transitionRe = /\btransition\b([\s\S]*?);/g;
+        let m: RegExpExecArray | null;
+        while ((m = transitionRe.exec(cleaned)) !== null) {
+            const body = m[1];
+            const first = firstRe.exec(body);
+            const then = thenRe.exec(body);
+            if (first && then) {
+                const accept = acceptRe.exec(body);
+                out.push({
+                    type: 'transition',
+                    source: stripQuotes(first[1]),
+                    target: stripQuotes(then[1]),
+                    name: accept ? stripQuotes(accept[1]) : '',
+                });
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Sentinel name used as the `source` of an initial transition so the
+     * State Transition View can render it as an initial pseudostate
+     * (`[*] → firstState`).  Kept unlikely to collide with a real name.
+     */
+    public static readonly INITIAL_PSEUDOSTATE = '__sysml_initial__';
+
+    /**
+     * Extract initial (entry) transitions from raw SysML source.
+     *
+     * A state machine's entry point is written as `entry; then FirstState;`
+     * (or `entry then FirstState`).  The LSP does not surface this as an
+     * edge, so we recover it and represent it as a transition from the
+     * initial pseudostate to the first state — mirroring `[*] --> First`
+     * in a UML/Mermaid state diagram.
+     */
+    public static extractInitialTransitions(
+        text: string,
+    ): { type: string; source: string; target: string; name: string }[] {
+        const cleaned = text
+            .replace(/\/\/[^\n]*/g, ' ')
+            .replace(/\/\*[\s\S]*?\*\//g, ' ');
+
+        const ref = "('[^']*'|[A-Za-z_][\\w.:]*)";
+        const stripQuotes = (s: string): string =>
+            s.startsWith("'") && s.endsWith("'") ? s.slice(1, -1) : s;
+
+        const out: { type: string; source: string; target: string; name: string }[] = [];
+        // `entry` optionally followed by an entry action up to its `;`, then
+        // the `then <target>` succession that names the first state.
+        const entryRe = new RegExp(`\\bentry\\b(?:[^;]*;)?\\s*then\\s+${ref}`, 'g');
+        let m: RegExpExecArray | null;
+        while ((m = entryRe.exec(cleaned)) !== null) {
+            out.push({
+                type: 'transition',
+                source: VisualizationPanel.INITIAL_PSEUDOSTATE,
+                target: stripQuotes(m[1]),
+                name: '',
+            });
+        }
+        return out;
+    }
+
+    /**
+     * Extract `then`-succession transitions between states.
+     *
+     * SysML lets successions be written as a chain of state declarations
+     * joined by `then` (e.g. `state idle; then state active; then state
+     * fault;`), which imply the transitions idle → active → fault.  These
+     * carry no `transition` keyword, so they are missed by
+     * {@link extractTransitionRelationships}.  Only successions whose
+     * endpoints are both declared states are emitted, so action-flow
+     * successions (`then action …`) and other `then` uses are ignored.
+     * Explicit `transition` statements and `entry` initial transitions are
+     * skipped here (handled by the other extractors).
+     */
+    public static extractSuccessionTransitions(
+        text: string,
+    ): { type: string; source: string; target: string; name: string }[] {
+        const cleaned = text
+            .replace(/\/\/[^\n]*/g, ' ')
+            .replace(/\/\*[\s\S]*?\*\//g, ' ');
+
+        const ref = "('[^']*'|[A-Za-z_][\\w.:]*)";
+        const stripQuotes = (s: string): string =>
+            s.startsWith("'") && s.endsWith("'") ? s.slice(1, -1) : s;
+        const simple = (name: string): string => {
+            const right = name.split('::').pop() ?? name;
+            return right.split('.').pop() ?? right;
+        };
+
+        // Pass 1 — collect the names of declared states.
+        const declared = new Set<string>();
+        const declRe = new RegExp(`\\bstate\\s+(?!def\\b)${ref}|\\bthen\\s+state\\s+${ref}`, 'g');
+        let dm: RegExpExecArray | null;
+        while ((dm = declRe.exec(cleaned)) !== null) {
+            const nm = stripQuotes(dm[1] ?? dm[2] ?? '');
+            if (nm) { declared.add(simple(nm)); }
+        }
+        if (declared.size === 0) { return []; }
+
+        // Pass 2 — walk tokens, tracking the current source state per brace
+        // scope, and emit an edge for each `then` between two declared states.
+        const out: { type: string; source: string; target: string; name: string }[] = [];
+        const tokenRe = new RegExp(
+            `(\\{)|(\\})|\\btransition\\b|\\bentry\\b|\\bfirst\\s+${ref}`
+            + `|\\bthen\\s+(?:state\\s+)?${ref}|\\bstate\\s+(?!def\\b)${ref}`,
+            'g',
+        );
+        const stack: (string | null)[] = [];
+        let current: string | null = null;
+        let pendingFirst: string | null = null;
+        let entryInitial = false;
+
+        let m: RegExpExecArray | null;
+        while ((m = tokenRe.exec(cleaned)) !== null) {
+            const tok = m[0];
+            if (m[1]) { stack.push(current); current = null; pendingFirst = null; continue; }
+            if (m[2]) { current = stack.pop() ?? null; pendingFirst = null; continue; }
+            if (/^transition\b/.test(tok)) {
+                // Skip the whole transition statement (handled elsewhere).
+                const semi = cleaned.indexOf(';', tokenRe.lastIndex);
+                tokenRe.lastIndex = semi === -1 ? cleaned.length : semi + 1;
+                pendingFirst = null;
+                continue;
+            }
+            if (/^entry\b/.test(tok)) { entryInitial = true; pendingFirst = null; continue; }
+            if (m[3] !== undefined) { pendingFirst = simple(stripQuotes(m[3])); continue; }
+            if (m[4] !== undefined) {
+                const target = simple(stripQuotes(m[4]));
+                const source = pendingFirst ?? current;
+                if (entryInitial) {
+                    // Initial transition — handled by extractInitialTransitions.
+                    entryInitial = false;
+                } else if (source && declared.has(source) && declared.has(target)) {
+                    out.push({ type: 'transition', source, target, name: '' });
+                }
+                current = target;
+                pendingFirst = null;
+                continue;
+            }
+            if (m[5] !== undefined) {
+                current = simple(stripQuotes(m[5]));
+                pendingFirst = null;
+            }
+        }
+        return out;
     }
 
     /**
@@ -1760,7 +1995,8 @@ export class VisualizationPanel {
         let sysmlMode = 'hierarchy';
         let layoutDirection = 'horizontal'; // Universal layout direction: 'horizontal', 'vertical', or 'auto'
         let activityLayoutDirection = 'vertical'; // Activity diagrams default to top-down
-        let stateLayoutOrientation = 'horizontal'; // Layout direction: 'horizontal', 'vertical', or 'force'
+        let stateLayoutDirection = 'vertical'; // State diagrams default to top-down
+        let stateLayoutOrientation = 'vertical'; // Layout direction: 'horizontal', 'vertical', or 'force'
         let usecaseLayoutOrientation = 'horizontal'; // Use case layout: 'horizontal', 'vertical', or 'force'
         let filteredData = null; // Active filter state shared across views
         let isRendering = false;
@@ -6495,8 +6731,10 @@ export class VisualizationPanel {
         function updateLayoutDirectionButton(activeView) {
             const layoutBtn = document.getElementById('layout-direction-btn');
             if (layoutBtn) {
-                // Use activity-specific direction for activity view
-                const effectiveDirection = activeView === 'activity' ? activityLayoutDirection : layoutDirection;
+                // Use view-specific direction for activity and state views
+                const effectiveDirection = activeView === 'activity' ? activityLayoutDirection
+                    : activeView === 'state' ? stateLayoutDirection
+                    : layoutDirection;
                 const icon = LAYOUT_DIRECTION_ICONS[effectiveDirection] || '→';
                 const label = LAYOUT_DIRECTION_LABELS[effectiveDirection] || 'Left → Right';
                 layoutBtn.textContent = icon + ' ' + label;
@@ -6507,7 +6745,7 @@ export class VisualizationPanel {
                 layoutBtn.title = 'Switch to ' + nextLabel;
 
                 // Sync with view-specific orientations for backwards compatibility
-                stateLayoutOrientation = layoutDirection === 'auto' ? 'force' : layoutDirection;
+                stateLayoutOrientation = stateLayoutDirection === 'auto' ? 'force' : stateLayoutDirection;
                 usecaseLayoutOrientation = layoutDirection === 'auto' ? 'force' : layoutDirection;
             }
         }
@@ -6519,9 +6757,11 @@ export class VisualizationPanel {
         }
 
         function toggleLayoutDirection() {
-            // Use activity-specific direction for activity view
+            // Use view-specific direction for activity and state views
             if (currentView === 'activity') {
                 activityLayoutDirection = getNextLayoutDirection(activityLayoutDirection);
+            } else if (currentView === 'state') {
+                stateLayoutDirection = getNextLayoutDirection(stateLayoutDirection);
             } else {
                 layoutDirection = getNextLayoutDirection(layoutDirection);
             }
@@ -6582,8 +6822,8 @@ export class VisualizationPanel {
         }
 
         function toggleStateLayout() {
-            layoutDirection = getNextLayoutDirection(layoutDirection);
-            stateLayoutOrientation = layoutDirection === 'auto' ? 'force' : layoutDirection;
+            stateLayoutDirection = getNextLayoutDirection(stateLayoutDirection);
+            stateLayoutOrientation = stateLayoutDirection === 'auto' ? 'force' : stateLayoutDirection;
             updateLayoutDirectionButton(currentView);
             // Re-render the state view
             if (currentView === 'state') {
@@ -13815,6 +14055,44 @@ export class VisualizationPanel {
                 return dotParts[dotParts.length - 1] || rightMostColon;
             };
 
+            // Synthesize nodes for transition endpoints referenced by
+            // 'first'/'then' (or the initial 'entry; then …') that were never
+            // declared with an explicit 'state'.  Valid SysML v2 lets a
+            // transition name a target state defined only by the transition,
+            // and the initial pseudostate has no declaration at all — without
+            // this, those transitions would be silently dropped.
+            const INITIAL_PSEUDOSTATE = '__sysml_initial__';
+            const transitionsForNodes = selectedMachine.transitions || transitions;
+            const declaredStateNames = new Set();
+            stateUsages.forEach(s => {
+                const nm = String(s.name || '');
+                if (nm) {
+                    declaredStateNames.add(nm);
+                    declaredStateNames.add(getSimpleStateName(nm));
+                }
+            });
+            transitionsForNodes.forEach(t => {
+                [t.source, t.target].forEach(ref => {
+                    const raw = String(ref || '').trim();
+                    if (!raw) {
+                        return;
+                    }
+                    if (raw === INITIAL_PSEUDOSTATE) {
+                        if (!stateUsages.some(s => s.id === INITIAL_PSEUDOSTATE)) {
+                            stateUsages.push({ id: INITIAL_PSEUDOSTATE, name: '', type: 'initial' });
+                        }
+                        return;
+                    }
+                    const simple = getSimpleStateName(raw);
+                    if (!simple || declaredStateNames.has(raw) || declaredStateNames.has(simple)) {
+                        return;
+                    }
+                    declaredStateNames.add(raw);
+                    declaredStateNames.add(simple);
+                    stateUsages.push({ name: simple, type: 'state' });
+                });
+            });
+
             const stateKeys = new Set(stateUsages.map(s => getStateKey(s)));
             const stateNameToKey = new Map();
             stateUsages.forEach(s => {
@@ -13868,11 +14146,15 @@ export class VisualizationPanel {
             const levels = new Map(); // stateKey -> level
             const visited = new Set();
 
-            // Find root states (no incoming or initial states)
+            // Find root states that drive the flow layout: the initial
+            // pseudostate, or a state with no incoming transition that still
+            // leads somewhere.  Fully isolated states (no transitions at all)
+            // are NOT roots — otherwise they float at the top of the diagram.
             const roots = stateUsages.filter(s => {
                 const key = getStateKey(s);
                 const inc = incoming.get(key) || [];
-                return inc.length === 0 || initialStates.includes(s);
+                const out = outgoing.get(key) || [];
+                return initialStates.includes(s) || (inc.length === 0 && out.length > 0);
             });
 
             // BFS to assign levels
@@ -13900,11 +14182,14 @@ export class VisualizationPanel {
                 });
             }
 
-            // Add any unvisited states
+            // Place any states not reached by the flow (isolated states) on a
+            // single level below the connected flow so they sit at the bottom
+            // instead of floating at the top.
+            const bottomLevel = Math.max(...Array.from(levels.values()), 0) + 1;
             stateUsages.forEach(s => {
                 const key = getStateKey(s);
                 if (!visited.has(key)) {
-                    levels.set(key, Math.max(...Array.from(levels.values()), 0) + 1);
+                    levels.set(key, bottomLevel);
                 }
             });
 
@@ -14109,10 +14394,24 @@ export class VisualizationPanel {
                     }
                 }
 
+                // The initial pseudostate is drawn as a small circle centred in
+                // its cell rather than a full-size box.  Anchor the edge on the
+                // circle's edge so there is no visible gap between the start
+                // circle and the entry arrow.
+                if (sourceKey === INITIAL_PSEUDOSTATE) {
+                    const cx = sx + stateWidth / 2;
+                    const cy = sy + stateHeight / 2;
+                    const r = 15;
+                    const vx = endX - cx;
+                    const vy = endY - cy;
+                    const len = Math.sqrt(vx * vx + vy * vy) || 1;
+                    startX = cx + (vx / len) * r;
+                    startY = cy + (vy / len) * r;
+                }
+
                 // Curved path with control points
                 const midX = (startX + endX) / 2;
                 const midY = (startY + endY) / 2;
-
                 // Add slight curve to avoid overlap
                 const curveOffset = offset * 0.5;
                 const controlX = midX + curveOffset;


### PR DESCRIPTION
- Bump VSCode engine version to ^1.125.0 and update related devDependencies.
- Implement comprehensive tests for state transition extraction, covering various scenarios including multi-line transitions, inline transitions, and handling of comments.
- Enhance the VisualizationPanel class to extract transition relationships directly from SysML source code, including initial transitions and succession transitions.
- Improve layout handling for state diagrams, ensuring proper rendering of initial pseudostates and isolated states.